### PR TITLE
fix css module mock in testing plugins

### DIFF
--- a/plugins/enzyme/package.json
+++ b/plugins/enzyme/package.json
@@ -1,12 +1,13 @@
 {
     "scripts": {
-      "test": "jest -c test/jest.config.js"
+        "test": "jest -c test/jest.config.js"
     },
     "devDependencies": {
-      "@types/enzyme": "^3.10.8",
-      "@wojtekmaj/enzyme-adapter-react-17": "^0.4.1",
-      "enzyme": "^3.11.0",
-      "jest": "^26.6.3",
-      "ts-jest": "^26.4.4"
-      }
-  }
+        "@types/enzyme": "^3.10.8",
+        "@wojtekmaj/enzyme-adapter-react-17": "^0.4.1",
+        "identity-obj-proxy": "^3.0.0",
+        "enzyme": "^3.11.0",
+        "jest": "^26.6.3",
+        "ts-jest": "^26.4.4"
+    }
+}

--- a/plugins/jest/package.json
+++ b/plugins/jest/package.json
@@ -1,9 +1,10 @@
 {
     "scripts": {
-      "test": "jest -c test/jest.config.js"
+        "test": "jest -c test/jest.config.js"
     },
     "devDependencies": {
-      "jest": "^26.6.3",
-      "ts-jest": "^26.4.4"
-      }
-  }
+        "jest": "^26.6.3",
+        "ts-jest": "^26.4.4",
+        "identity-obj-proxy": "^3.0.0"
+    }
+}

--- a/plugins/testing-library/package.json
+++ b/plugins/testing-library/package.json
@@ -5,6 +5,7 @@
     "devDependencies": {
         "@testing-library/react": "^11.2.3",
         "@testing-library/react-hooks": "^5.0.0",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^26.6.3",
         "ts-jest": "^26.4.4"
     }


### PR DESCRIPTION
- [x] jest
- [x] testing-library
- [x] enzyme

`identity-obj-proxy`'i devdep olarak ekledim ekstra bir sey yapmiyor gelen tum istekleri proxyle dondurmek disinda. kendimiz mock yazmaktansa zaten bundle'i buyutmeyecegi icin paketi kullanmak daha mantikli olacak bence.

Resolves #114 