### PR TITLE
Fix redux counter test fail

### DIFF
--- a/react/plugins/redux/src/redux/slices/counter/index.spec.ts
+++ b/react/plugins/redux/src/redux/slices/counter/index.spec.ts
@@ -5,7 +5,7 @@ describe("Redux Counter Reducer", () => {
         const initial = {
             count: 0,
         };
-        const reducer = Counter(initial, {});
+        const reducer = Counter(initial, { type: {} });
         expect(reducer).toEqual(initial);
     });
     it("increase action should increase counter by 1", () => {


### PR DESCRIPTION
Shows an error on the test file during the initial project running after successfully building with CLI using Redux as a plugin. 
To fix, I added a type parameter as shown on the error.

`TS2345: Argument of type '{}' is not assignable to parameter of type 'AnyAction'.
  Property 'type' is missing in type '{}' but required in type 'AnyAction'.`