### PR TITLE
refactor: replace `useMenu` import with `@pankod/refine-core`

### DIFF
--- a/refine-nextjs/plugins/custom-layout/src/components/layout/sider/index.tsx
+++ b/refine-nextjs/plugins/custom-layout/src/components/layout/sider/index.tsx
@@ -10,6 +10,7 @@ import {
     useTitle,
     CanAccess,
     ITreeMenu,
+    useMenu,
     useRouterContext
 } from "@pankod/refine-core";
 
@@ -18,7 +19,6 @@ import {
     Menu,
     Grid,
     Icons,
-    useMenu,
 } from "@pankod/refine-antd";
 import { antLayoutSider, antLayoutSiderMobile } from "./styles";
 

--- a/refine-nextjs/plugins/custom-layout/src/components/layout/sider/index.tsx
+++ b/refine-nextjs/plugins/custom-layout/src/components/layout/sider/index.tsx
@@ -11,6 +11,7 @@ import {
     CanAccess,
     ITreeMenu,
     useMenu,
+    useRefineContext,
     useRouterContext
 } from "@pankod/refine-core";
 
@@ -35,6 +36,7 @@ export const Sider: React.FC = () => {
     const { mutate: logout } = useLogout();
     <%_ } _%>
     const { Link } = useRouterContext();
+    const { hasDashboard } = useRefineContext();
     const Title = useTitle();
     const { SubMenu } = Menu;
 
@@ -108,6 +110,27 @@ export const Sider: React.FC = () => {
                     }
                 }}
             >
+                {hasDashboard && (
+                    <Menu.Item
+                        key="dashboard"
+                        style={{
+                            fontWeight: selectedKey === "/" ? "bold" : "normal",
+                        }}
+                        icon={<Icons.DashboardOutlined />}
+                    >
+                        <Link href="/" to="/">
+                        <%_ if (i18n !== "no") { _%>
+                            {translate("dashboard.title", "Dashboard")}
+                        <%_ } else { _%>
+                            Dashboard
+                        <%_ } _%>
+                        </Link>
+                        {!collapsed && selectedKey === "/" && (
+                            <div className="ant-menu-tree-arrow" />
+                        )}
+                    </Menu.Item>
+                )}
+
                 {renderTreeView(menuItems, selectedKey)}
 
                     <%_ if (answers["auth-provider"] !== 'none' || answers["dataProvider"] == 'strapi-data-provider' || answers["dataProvider"] == 'strapi-graphql-data-provider' || answers["dataProvider"] == 'supabase-data-provider') { _%>

--- a/refine-nextjs/plugins/custom-layout/src/components/layout/sider/index.tsx
+++ b/refine-nextjs/plugins/custom-layout/src/components/layout/sider/index.tsx
@@ -53,7 +53,7 @@ export const Sider: React.FC = () => {
             if (children.length > 0) {
                 return (
                     <SubMenu
-                        key={name}
+                        key={route}
                         icon={icon ?? <UnorderedListOutlined />}
                         title={label}
                     >
@@ -72,7 +72,7 @@ export const Sider: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}

--- a/refine-nextjs/plugins/custom-layout/src/components/layout/sider/index.tsx
+++ b/refine-nextjs/plugins/custom-layout/src/components/layout/sider/index.tsx
@@ -18,7 +18,7 @@ import {
     AntdLayout,
     Menu,
     Grid,
-    Icons,
+    Icons
 } from "@pankod/refine-antd";
 import { antLayoutSider, antLayoutSiderMobile } from "./styles";
 

--- a/refine-react/plugins/custom-layout/src/components/layout/sider/index.tsx
+++ b/refine-react/plugins/custom-layout/src/components/layout/sider/index.tsx
@@ -11,6 +11,7 @@ import {
     CanAccess,
     ITreeMenu,
     useMenu,
+    useRefineContext,
     useRouterContext
 } from "@pankod/refine-core";
 import {
@@ -36,6 +37,7 @@ export const Sider: React.FC = () => {
     <%_ } _%>
 
     const { Link } = useRouterContext();
+    const { hasDashboard } = useRefineContext();
     const Title = useTitle();
     const { SubMenu } = Menu;
 
@@ -109,6 +111,27 @@ export const Sider: React.FC = () => {
                     }
                 }}
             >
+                    {hasDashboard && (
+                        <Menu.Item
+                            key="dashboard"
+                            style={{
+                                fontWeight: selectedKey === "/" ? "bold" : "normal",
+                            }}
+                            icon={<Icons.DashboardOutlined />}
+                        >
+                            <Link href="/" to="/">
+                            <%_ if (i18n !== "no") { _%>
+                                {translate("dashboard.title", "Dashboard")}
+                            <%_ } else { _%>
+                                Dashboard
+                            <%_ } _%>
+                            </Link>
+                            {!collapsed && selectedKey === "/" && (
+                                <div className="ant-menu-tree-arrow" />
+                            )}
+                        </Menu.Item>
+                    )}
+
                     {renderTreeView(menuItems, selectedKey)}   
 
                     <%_ if (answers["auth-provider"] !== 'none' || answers["dataProvider"] == 'strapi-data-provider' || answers["dataProvider"] == 'strapi-graphql-data-provider' || answers["dataProvider"] == 'supabase-data-provider') { _%>

--- a/refine-react/plugins/custom-layout/src/components/layout/sider/index.tsx
+++ b/refine-react/plugins/custom-layout/src/components/layout/sider/index.tsx
@@ -10,14 +10,14 @@ import {
     useTitle,
     CanAccess,
     ITreeMenu,
+    useMenu,
     useRouterContext
 } from "@pankod/refine-core";
 import {
     AntdLayout,
     Menu,
     Grid,
-    Icons,
-    useMenu
+    Icons
 } from "@pankod/refine-antd";
 import { antLayoutSider, antLayoutSiderMobile } from "./styles";
 
@@ -54,7 +54,7 @@ export const Sider: React.FC = () => {
             if (children.length > 0) {
                 return (
                     <SubMenu
-                        key={name}
+                        key={route}
                         icon={icon ?? <UnorderedListOutlined />}
                         title={label}
                     >
@@ -73,7 +73,7 @@ export const Sider: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}


### PR DESCRIPTION
Replaced `useMenu` import in custom sider component with the one from `@pankod/refine-core`.

Waiting https://github.com/pankod/refine/pull/1952 and https://github.com/pankod/refine/pull/1985