### PR TITLE
chore: add actions key to translation files

### DIFF
--- a/refine-nextjs/plugins/i18n-antd/public/locales/de/common.json
+++ b/refine-nextjs/plugins/i18n-antd/public/locales/de/common.json
@@ -17,6 +17,12 @@
             "backHome": "Zurück"
         }
     },
+    "actions": {
+        "list": "Aufführen",
+        "create": "Erstellen",
+        "edit": "Bearbeiten",
+        "show": "Zeigen"
+    },
     "buttons": {
         "create": "Erstellen",
         "save": "Speichern",

--- a/refine-nextjs/plugins/i18n-antd/public/locales/en/common.json
+++ b/refine-nextjs/plugins/i18n-antd/public/locales/en/common.json
@@ -17,6 +17,12 @@
             "backHome": "Back Home"
         }
     },
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
     "buttons": {
         "create": "Create",
         "save": "Save",

--- a/refine-nextjs/plugins/i18n-mui/public/locales/de/common.json
+++ b/refine-nextjs/plugins/i18n-mui/public/locales/de/common.json
@@ -17,6 +17,12 @@
             "backHome": "Zurück"
         }
     },
+    "actions": {
+        "list": "Aufführen",
+        "create": "Erstellen",
+        "edit": "Bearbeiten",
+        "show": "Zeigen"
+    },
     "buttons": {
         "create": "Erstellen",
         "save": "Speichern",

--- a/refine-nextjs/plugins/i18n-mui/public/locales/en/common.json
+++ b/refine-nextjs/plugins/i18n-mui/public/locales/en/common.json
@@ -17,6 +17,12 @@
             "backHome": "Back Home"
         }
     },
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
     "buttons": {
         "create": "Create",
         "save": "Save",

--- a/refine-nextjs/plugins/i18n/public/locales/de/common.json
+++ b/refine-nextjs/plugins/i18n/public/locales/de/common.json
@@ -17,6 +17,12 @@
             "backHome": "Zurück"
         }
     },
+    "actions": {
+        "list": "Aufführen",
+        "create": "Erstellen",
+        "edit": "Bearbeiten",
+        "show": "Zeigen"
+    },
     "buttons": {
         "create": "Erstellen",
         "save": "Speichern",
@@ -32,7 +38,7 @@
         "undo": "Undo",
         "import": "Importieren",
         "clone": "Klon",
-        "notAccessTitle": "Sie haben keine zugriffsberechtigung",
+        "notAccessTitle": "Sie haben keine zugriffsberechtigung"
     },
     "warnWhenUnsavedChanges": "Nicht gespeicherte Änderungen werden nicht übernommen.",
     "notifications": {

--- a/refine-nextjs/plugins/i18n/public/locales/en/common.json
+++ b/refine-nextjs/plugins/i18n/public/locales/en/common.json
@@ -17,6 +17,12 @@
             "backHome": "Back Home"
         }
     },
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
     "buttons": {
         "create": "Create",
         "save": "Save",

--- a/refine-react/plugins/i18n-antd/public/locales/de/common.json
+++ b/refine-react/plugins/i18n-antd/public/locales/de/common.json
@@ -17,6 +17,12 @@
             "backHome": "Zurück"
         }
     },
+    "actions": {
+        "list": "Aufführen",
+        "create": "Erstellen",
+        "edit": "Bearbeiten",
+        "show": "Zeigen"
+    },
     "buttons": {
         "create": "Erstellen",
         "save": "Speichern",

--- a/refine-react/plugins/i18n-antd/public/locales/en/common.json
+++ b/refine-react/plugins/i18n-antd/public/locales/en/common.json
@@ -17,6 +17,12 @@
             "backHome": "Back Home"
         }
     },
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
     "buttons": {
         "create": "Create",
         "save": "Save",

--- a/refine-react/plugins/i18n-mui/public/locales/de.json
+++ b/refine-react/plugins/i18n-mui/public/locales/de.json
@@ -17,6 +17,12 @@
             "backHome": "Zurück"
         }
     },
+    "actions": {
+        "list": "Aufführen",
+        "create": "Erstellen",
+        "edit": "Bearbeiten",
+        "show": "Zeigen"
+    },
     "buttons": {
         "create": "Erstellen",
         "save": "Speichern",

--- a/refine-react/plugins/i18n-mui/public/locales/en.json
+++ b/refine-react/plugins/i18n-mui/public/locales/en.json
@@ -17,6 +17,12 @@
             "backHome": "Back Home"
         }
     },
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
     "buttons": {
         "create": "Create",
         "save": "Save",

--- a/refine-react/plugins/i18n/public/locales/de/common.json
+++ b/refine-react/plugins/i18n/public/locales/de/common.json
@@ -17,6 +17,12 @@
             "backHome": "Zurück"
         }
     },
+    "actions": {
+        "list": "Aufführen",
+        "create": "Erstellen",
+        "edit": "Bearbeiten",
+        "show": "Zeigen"
+    },
     "buttons": {
         "create": "Erstellen",
         "save": "Speichern",

--- a/refine-react/plugins/i18n/public/locales/en/common.json
+++ b/refine-react/plugins/i18n/public/locales/en/common.json
@@ -17,6 +17,12 @@
             "backHome": "Back Home"
         }
     },
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
     "buttons": {
         "create": "Create",
         "save": "Save",


### PR DESCRIPTION
added actions key for [`useBreadcrumb`](https://refine.dev/docs/core/hooks/useBreadcrumb/#translate) hook.

```
German
    "actions": {
        "list": "Aufführen",
        "create": "Erstellen",
        "edit": "Bearbeiten",
        "show": "Zeigen"
    },

English
    "actions": {
        "list": "List",
        "create": "Create",
        "edit": "Edit",
        "show": "Show"
    },
```