### PR TITLE
fix(refine): move dark mode prompts before customization

### DIFF
--- a/refine-nextjs/prompt.js
+++ b/refine-nextjs/prompt.js
@@ -169,6 +169,66 @@ module.exports = {
             skip: ({ answers }) => answers["ui-framework"] !== "antd",
         },
         {
+            name: "mui-dark-mode",
+            message: "Do you want to add dark mode support?:",
+            type: "select",
+            pageSize: 2,
+            choices: [
+                {
+                    message: "No",
+                    name: "no",
+                    hint: "Only light theme will be installed.",
+                },
+                {
+                    message: "Yes",
+                    name: "mui-dark-mode",
+                    hint: "Both light & dark themes will be installed.",
+                },
+            ],
+            default: "no",
+            skip: ({ answers }) => answers["ui-framework"] !== "mui",
+        },
+        {
+            name: "mantine-dark-mode",
+            message: "Do you want to add dark mode support?:",
+            type: "select",
+            pageSize: 2,
+            choices: [
+                {
+                    message: "No",
+                    name: "no",
+                    hint: "Only light theme will be installed.",
+                },
+                {
+                    message: "Yes",
+                    name: "mantine-dark-mode",
+                    hint: "Both light & dark themes will be installed.",
+                },
+            ],
+            default: "no",
+            skip: ({ answers }) => answers["ui-framework"] !== "mantine",
+        },
+        {
+            name: "chakra-dark-mode",
+            message: "Do you want to add dark mode support?:",
+            type: "select",
+            pageSize: 2,
+            choices: [
+                {
+                    message: "No",
+                    name: "no",
+                    hint: "Only light theme will be installed.",
+                },
+                {
+                    message: "Yes",
+                    name: "chakra-dark-mode",
+                    hint: "Both light & dark themes will be installed.",
+                },
+            ],
+            default: "no",
+            skip: ({ answers }) => answers["ui-framework"] !== "chakra",
+        },
+        {
             name: "mui-extend-theme",
             message: "Do you want to customize the Material UI theme?:",
             type: "select",
@@ -263,66 +323,6 @@ module.exports = {
                     name: "chakra-custom-layout",
                     hint:
                         "Enables custom page layout (Sider, header, footer etc.)",
-                },
-            ],
-            default: "no",
-            skip: ({ answers }) => answers["ui-framework"] !== "chakra",
-        },
-        {
-            name: "mui-dark-mode",
-            message: "Do you want to add dark mode support?:",
-            type: "select",
-            pageSize: 2,
-            choices: [
-                {
-                    message: "No",
-                    name: "no",
-                    hint: "Only light theme will be installed.",
-                },
-                {
-                    message: "Yes",
-                    name: "mui-dark-mode",
-                    hint: "Both light & dark themes will be installed.",
-                },
-            ],
-            default: "no",
-            skip: ({ answers }) => answers["ui-framework"] !== "mui",
-        },
-        {
-            name: "mantine-dark-mode",
-            message: "Do you want to add dark mode support?:",
-            type: "select",
-            pageSize: 2,
-            choices: [
-                {
-                    message: "No",
-                    name: "no",
-                    hint: "Only light theme will be installed.",
-                },
-                {
-                    message: "Yes",
-                    name: "mantine-dark-mode",
-                    hint: "Both light & dark themes will be installed.",
-                },
-            ],
-            default: "no",
-            skip: ({ answers }) => answers["ui-framework"] !== "mantine",
-        },
-        {
-            name: "chakra-dark-mode",
-            message: "Do you want to add dark mode support?:",
-            type: "select",
-            pageSize: 2,
-            choices: [
-                {
-                    message: "No",
-                    name: "no",
-                    hint: "Only light theme will be installed.",
-                },
-                {
-                    message: "Yes",
-                    name: "chakra-dark-mode",
-                    hint: "Both light & dark themes will be installed.",
                 },
             ],
             default: "no",

--- a/refine-react/prompt.js
+++ b/refine-react/prompt.js
@@ -174,6 +174,66 @@ module.exports = {
             skip: ({ answers }) => answers["ui-framework"] !== "antd",
         },
         {
+            name: "mui-dark-mode",
+            message: "Do you want to add dark mode support?:",
+            type: "select",
+            pageSize: 2,
+            choices: [
+                {
+                    message: "No",
+                    name: "no",
+                    hint: "Only light theme will be installed.",
+                },
+                {
+                    message: "Yes",
+                    name: "mui-dark-mode",
+                    hint: "Both light & dark themes will be installed.",
+                },
+            ],
+            default: "no",
+            skip: ({ answers }) => answers["ui-framework"] !== "mui",
+        },
+        {
+            name: "mantine-dark-mode",
+            message: "Do you want to add dark mode support?:",
+            type: "select",
+            pageSize: 2,
+            choices: [
+                {
+                    message: "No",
+                    name: "no",
+                    hint: "Only light theme will be installed.",
+                },
+                {
+                    message: "Yes",
+                    name: "mantine-dark-mode",
+                    hint: "Both light & dark themes will be installed.",
+                },
+            ],
+            default: "no",
+            skip: ({ answers }) => answers["ui-framework"] !== "mantine",
+        },
+        {
+            name: "chakra-dark-mode",
+            message: "Do you want to add dark mode support?:",
+            type: "select",
+            pageSize: 2,
+            choices: [
+                {
+                    message: "No",
+                    name: "no",
+                    hint: "Only light theme will be installed.",
+                },
+                {
+                    message: "Yes",
+                    name: "chakra-dark-mode",
+                    hint: "Both light & dark themes will be installed.",
+                },
+            ],
+            default: "no",
+            skip: ({ answers }) => answers["ui-framework"] !== "chakra",
+        },
+        {
             name: "mui-extend-theme",
             message: "Do you want to customize the Material UI theme?:",
             type: "select",
@@ -268,66 +328,6 @@ module.exports = {
                     name: "chakra-custom-layout",
                     hint:
                         "Enables custom page layout (Sider, header, footer etc.)",
-                },
-            ],
-            default: "no",
-            skip: ({ answers }) => answers["ui-framework"] !== "chakra",
-        },
-        {
-            name: "mui-dark-mode",
-            message: "Do you want to add dark mode support?:",
-            type: "select",
-            pageSize: 2,
-            choices: [
-                {
-                    message: "No",
-                    name: "no",
-                    hint: "Only light theme will be installed.",
-                },
-                {
-                    message: "Yes",
-                    name: "mui-dark-mode",
-                    hint: "Both light & dark themes will be installed.",
-                },
-            ],
-            default: "no",
-            skip: ({ answers }) => answers["ui-framework"] !== "mui",
-        },
-        {
-            name: "mantine-dark-mode",
-            message: "Do you want to add dark mode support?:",
-            type: "select",
-            pageSize: 2,
-            choices: [
-                {
-                    message: "No",
-                    name: "no",
-                    hint: "Only light theme will be installed.",
-                },
-                {
-                    message: "Yes",
-                    name: "mantine-dark-mode",
-                    hint: "Both light & dark themes will be installed.",
-                },
-            ],
-            default: "no",
-            skip: ({ answers }) => answers["ui-framework"] !== "mantine",
-        },
-        {
-            name: "chakra-dark-mode",
-            message: "Do you want to add dark mode support?:",
-            type: "select",
-            pageSize: 2,
-            choices: [
-                {
-                    message: "No",
-                    name: "no",
-                    hint: "Only light theme will be installed.",
-                },
-                {
-                    message: "Yes",
-                    name: "chakra-dark-mode",
-                    hint: "Both light & dark themes will be installed.",
                 },
             ],
             default: "no",

--- a/refine-remix/plugins/chakra/app/root.tsx
+++ b/refine-remix/plugins/chakra/app/root.tsx
@@ -18,12 +18,6 @@ import routerProvider from "@pankod/refine-remix-router";
 
 import { ServerStyleContext, ClientStyleContext } from './context'
 
-export const meta: MetaFunction = () => ({
-  charset: 'utf-8',
-  title: 'New Remix App',
-  viewport: 'width=device-width,initial-scale=1',
-});
-
 <%- (_app.import || []).join("\n") _%>
 
 <%- (_app.localImport || []).join("\n") _%>
@@ -31,6 +25,12 @@ export const meta: MetaFunction = () => ({
 <%- (_app.relativeImport || []).join("\n") _%>
 
 <%- (_app.afterImport || []).join("\n") _%>
+
+export const meta: MetaFunction = () => ({
+  charset: 'utf-8',
+  title: 'New Remix App',
+  viewport: 'width=device-width,initial-scale=1',
+});
 
 <%
     var top = _app.wrapper.map(wrapper => wrapper[0] || "");

--- a/refine-remix/prompt.js
+++ b/refine-remix/prompt.js
@@ -169,6 +169,66 @@ module.exports = {
             skip: ({ answers }) => answers["ui-framework"] !== "antd",
         },
         {
+            name: "mui-dark-mode",
+            message: "Do you want to add dark mode support?:",
+            type: "select",
+            pageSize: 2,
+            choices: [
+                {
+                    message: "No",
+                    name: "no",
+                    hint: "Only light theme will be installed.",
+                },
+                {
+                    message: "Yes",
+                    name: "mui-dark-mode",
+                    hint: "Both light & dark themes will be installed.",
+                },
+            ],
+            default: "no",
+            skip: ({ answers }) => answers["ui-framework"] !== "mui",
+        },
+        {
+            name: "mantine-dark-mode",
+            message: "Do you want to add dark mode support?:",
+            type: "select",
+            pageSize: 2,
+            choices: [
+                {
+                    message: "No",
+                    name: "no",
+                    hint: "Only light theme will be installed.",
+                },
+                {
+                    message: "Yes",
+                    name: "mantine-dark-mode",
+                    hint: "Both light & dark themes will be installed.",
+                },
+            ],
+            default: "no",
+            skip: ({ answers }) => answers["ui-framework"] !== "mantine",
+        },
+        {
+            name: "chakra-dark-mode",
+            message: "Do you want to add dark mode support?:",
+            type: "select",
+            pageSize: 2,
+            choices: [
+                {
+                    message: "No",
+                    name: "no",
+                    hint: "Only light theme will be installed.",
+                },
+                {
+                    message: "Yes",
+                    name: "chakra-dark-mode",
+                    hint: "Both light & dark themes will be installed.",
+                },
+            ],
+            default: "no",
+            skip: ({ answers }) => answers["ui-framework"] !== "chakra",
+        },
+        {
             name: "mui-extend-theme",
             message: "Do you want an extended theme?:",
             type: "select",
@@ -259,66 +319,6 @@ module.exports = {
                     name: "chakra-custom-layout",
                     hint:
                         "Enables custom page layout (Sider, header, footer etc.)",
-                },
-            ],
-            default: "no",
-            skip: ({ answers }) => answers["ui-framework"] !== "chakra",
-        },
-        {
-            name: "mui-dark-mode",
-            message: "Do you want to add dark mode support?:",
-            type: "select",
-            pageSize: 2,
-            choices: [
-                {
-                    message: "No",
-                    name: "no",
-                    hint: "Only light theme will be installed.",
-                },
-                {
-                    message: "Yes",
-                    name: "mui-dark-mode",
-                    hint: "Both light & dark themes will be installed.",
-                },
-            ],
-            default: "no",
-            skip: ({ answers }) => answers["ui-framework"] !== "mui",
-        },
-        {
-            name: "mantine-dark-mode",
-            message: "Do you want to add dark mode support?:",
-            type: "select",
-            pageSize: 2,
-            choices: [
-                {
-                    message: "No",
-                    name: "no",
-                    hint: "Only light theme will be installed.",
-                },
-                {
-                    message: "Yes",
-                    name: "mantine-dark-mode",
-                    hint: "Both light & dark themes will be installed.",
-                },
-            ],
-            default: "no",
-            skip: ({ answers }) => answers["ui-framework"] !== "mantine",
-        },
-        {
-            name: "chakra-dark-mode",
-            message: "Do you want to add dark mode support?:",
-            type: "select",
-            pageSize: 2,
-            choices: [
-                {
-                    message: "No",
-                    name: "no",
-                    hint: "Only light theme will be installed.",
-                },
-                {
-                    message: "Yes",
-                    name: "chakra-dark-mode",
-                    hint: "Both light & dark themes will be installed.",
                 },
             ],
             default: "no",

--- a/refine-remix/template/.npmrc
+++ b/refine-remix/template/.npmrc
@@ -1,2 +1,4 @@
 legacy-peer-deps=true
 strict-peer-dependencies=false
+auto-install-peers=true
+shamefully-hoist=true


### PR DESCRIPTION
Updated dark mode prompt order and moved above customization.

Resolves https://github.com/refinedev/refine/issues/3464