### PR TITLE
feat(refine-react): update layout to themed-layout

### DIFF
--- a/refine-react/plugins/antd/extend.js
+++ b/refine-react/plugins/antd/extend.js
@@ -2,14 +2,18 @@ const base = {
     _app: {
         import: [],
         refineImports: [],
-        refineAntdImports: ["notificationProvider", "Layout", "ErrorComponent"],
+        refineAntdImports: [
+            "notificationProvider",
+            "ThemedLayout",
+            "ErrorComponent",
+        ],
         refineProps: ["notificationProvider={notificationProvider}"],
         wrapper: [
             [`<ColorModeContextProvider>`, `</ColorModeContextProvider>`],
         ],
         localImport: [
             `import { ColorModeContextProvider } from "./contexts/color-mode";`,
-            `import { Header } from "./components/header";`
+            `import { Header } from "./components/header";`,
         ],
     },
 };

--- a/refine-react/plugins/antd/src/components/header/index.tsx
+++ b/refine-react/plugins/antd/src/components/header/index.tsx
@@ -1,9 +1,17 @@
 import { useContext } from "react";
 import { useGetIdentity } from "@refinedev/core";
-import { Layout as AntdLayout, Space, Avatar, Typography, Switch } from "antd";
+import {
+    Layout as AntdLayout,
+    Space,
+    Avatar,
+    Typography,
+    Switch,
+    theme,
+} from "antd";
 import { ColorModeContext } from "../../contexts/color-mode";
 
 const { Text } = Typography;
+const { useToken } = theme;
 
 type IUser = {
     id: number;
@@ -12,15 +20,16 @@ type IUser = {
 };
 
 export const Header: React.FC = () => {
+    const { token } = useToken();
     const { data: user } = useGetIdentity<IUser>();
     const { mode, setMode } = useContext(ColorModeContext);
 
     return (
         <AntdLayout.Header
             style={{
+                backgroundColor: token.colorBgElevated,
                 display: "flex",
                 justifyContent: "flex-end",
-
                 alignItems: "center",
                 padding: "0px 24px",
                 height: "64px",
@@ -35,8 +44,8 @@ export const Header: React.FC = () => {
                     }
                     defaultChecked={mode === "dark"}
                 />
-                <Space style={{ marginLeft: "8px" }}>
-                    {user?.name && <Text style={{ color: "white" }} strong>{user.name}</Text>}
+                <Space style={{ marginLeft: "8px" }} size="middle">
+                    {user?.name && <Text strong>{user.name}</Text>}
                     {user?.avatar && (
                         <Avatar src={user?.avatar} alt={user?.name} />
                     )}

--- a/refine-react/plugins/antd/src/contexts/color-mode/index.tsx
+++ b/refine-react/plugins/antd/src/contexts/color-mode/index.tsx
@@ -1,10 +1,6 @@
-import {
-    PropsWithChildren,
-    createContext,
-    useEffect,
-    useState,
-} from "react";
+import { PropsWithChildren, createContext, useEffect, useState } from "react";
 import { ConfigProvider, theme } from "antd";
+import { RefineThemes } from "@refinedev/antd";
 
 type ColorModeContextType = {
     mode: string;
@@ -50,7 +46,9 @@ export const ColorModeContextProvider: React.FC<PropsWithChildren> = ({
             }}
         >
             <ConfigProvider
+                // you can change the theme colors here. example: ...RefineThemes.Magenta,
                 theme={{
+                    ...RefineThemes.Blue,
                     algorithm:
                         mode === "light" ? defaultAlgorithm : darkAlgorithm,
                 }}

--- a/refine-react/plugins/auth-provider-google/package.json
+++ b/refine-react/plugins/auth-provider-google/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "axios": "^0.26.1",
+        "axios": "^0.26.1"
     }
 }

--- a/refine-react/plugins/chakra/extend.js
+++ b/refine-react/plugins/chakra/extend.js
@@ -9,6 +9,10 @@ const base = {
             "ErrorComponent",
         ],
         wrapper: [
+            [
+                "{/* You can change the theme colors here. example: theme={RefineThemes.Magenta} */}",
+                "",
+            ],
             [`<ChakraProvider theme={RefineThemes.Blue}>`, "</ChakraProvider>"],
         ],
         localImport: [`import { Header } from "./components/header";`],

--- a/refine-react/plugins/chakra/extend.js
+++ b/refine-react/plugins/chakra/extend.js
@@ -1,23 +1,17 @@
 const base = {
     _app: {
-        refineProps: [
-            "notificationProvider={notificationProvider}",
-        ],
-        import: [
-            `import { ChakraProvider } from "@chakra-ui/react";`
-        ],
+        refineProps: ["notificationProvider={notificationProvider}"],
+        import: [`import { ChakraProvider } from "@chakra-ui/react";`],
         refineChakraImports: [
             "notificationProvider",
-            "refineTheme",
-            "Layout",
-            "ErrorComponent"
+            "RefineThemes",
+            "ThemedLayout",
+            "ErrorComponent",
         ],
         wrapper: [
-            [`<ChakraProvider theme={refineTheme}>`, "</ChakraProvider>"],
+            [`<ChakraProvider theme={RefineThemes.Blue}>`, "</ChakraProvider>"],
         ],
-        localImport: [
-            `import { Header } from "./components/header";`
-        ],
+        localImport: [`import { Header } from "./components/header";`],
     },
 };
 

--- a/refine-react/plugins/chakra/src/components/header/index.tsx
+++ b/refine-react/plugins/chakra/src/components/header/index.tsx
@@ -1,6 +1,21 @@
 import { useGetIdentity } from "@refinedev/core";
-import { Box, IconButton, HStack, Text, Avatar, Icon, useColorMode } from "@chakra-ui/react";
-import { IconMoon, IconSun } from "@tabler/icons";
+import {
+    Box,
+    IconButton,
+    HStack,
+    Text,
+    Avatar,
+    Icon,
+    useColorMode,
+    useColorModeValue,
+} from "@chakra-ui/react";
+import { RefineThemedLayoutHeaderProps } from "@refinedev/chakra-ui";
+import {
+    IconMoon,
+    IconSun,
+    IconLayoutSidebarLeftCollapse,
+    IconLayoutSidebarLeftExpand,
+} from "@tabler/icons";
 
 type IUser = {
     id: number;
@@ -8,41 +23,89 @@ type IUser = {
     avatar: string;
 };
 
-export const Header: React.FC = () => {
-  const { data: user } = useGetIdentity<IUser>();
-  const showUserInfo = user && (user.name || user.avatar);
+export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
+    isSiderOpen,
+    onToggleSiderClick,
+    toggleSiderIcon: toggleSiderIconFromProps,
+}) => {
+    const { data: user } = useGetIdentity<IUser>();
 
-  const { colorMode, toggleColorMode } = useColorMode();
+    const { colorMode, toggleColorMode } = useColorMode();
 
-  return (
-    <Box
-        py="2"
-        px="4"
-        display="flex"
-        justifyContent="flex-end"
-        gap={2}
-        w="full"
-        bg="chakra-body-bg"
-    >
-        <IconButton
-            variant="ghost"
-            aria-label="Toggle theme"
-            onClick={toggleColorMode}
+    const bgColor = useColorModeValue(
+        "refine.header.bg.light",
+        "refine.header.bg.dark",
+    );
+
+    const hasSidebarToggle = Boolean(onToggleSiderClick);
+
+    return (
+        <Box
+            py="2"
+            pr="4"
+            pl="2"
+            display="flex"
+            alignItems="center"
+            justifyContent={
+                hasSidebarToggle
+                    ? { base: "flex-end", md: "space-between" }
+                    : "flex-end"
+            }
+            w="full"
+            height="64px"
+            bg={bgColor}
+            borderBottom="1px"
+            borderBottomColor={useColorModeValue("gray.200", "gray.700")}
         >
-            <Icon
-                as={colorMode === "light" ? IconMoon : IconSun}
-                w="24px"
-                h="24px"
-            />
-        </IconButton>
-        {showUserInfo && (
-          <HStack>
-              <Text size="sm" fontWeight="bold">
-                  {user?.name}
-              </Text>
-              <Avatar size="sm" name={user?.name} src={user?.avatar} />
-          </HStack>
-        )}
-    </Box>
-);
+            {hasSidebarToggle && (
+                <IconButton
+                    display={{ base: "none", md: "flex" }}
+                    backgroundColor="transparent"
+                    aria-label="sidebar-toggle"
+                    onClick={() => onToggleSiderClick?.()}
+                >
+                    {toggleSiderIconFromProps?.(Boolean(isSiderOpen)) ??
+                        (isSiderOpen ? (
+                            <Icon
+                                as={IconLayoutSidebarLeftCollapse}
+                                boxSize={"24px"}
+                            />
+                        ) : (
+                            <Icon
+                                as={IconLayoutSidebarLeftExpand}
+                                boxSize={"24px"}
+                            />
+                        ))}
+                </IconButton>
+            )}
+
+            <HStack>
+                <IconButton
+                    variant="ghost"
+                    aria-label="Toggle theme"
+                    onClick={toggleColorMode}
+                >
+                    <Icon
+                        as={colorMode === "light" ? IconMoon : IconSun}
+                        w="24px"
+                        h="24px"
+                    />
+                </IconButton>
+                {(user?.avatar || user?.name) && (
+                    <HStack>
+                        {user?.name && (
+                            <Text size="sm" fontWeight="bold">
+                                {user.name}
+                            </Text>
+                        )}
+                        <Avatar
+                            size="sm"
+                            name={user?.name}
+                            src={user?.avatar}
+                        />
+                    </HStack>
+                )}
+            </HStack>
+        </Box>
+    );
 };

--- a/refine-react/plugins/chakra/src/components/index.ts
+++ b/refine-react/plugins/chakra/src/components/index.ts
@@ -1,1 +1,1 @@
-export { Header } from "./header"
+export { Header } from "./header";

--- a/refine-react/plugins/i18n-antd/src/components/header/index.tsx
+++ b/refine-react/plugins/i18n-antd/src/components/header/index.tsx
@@ -1,12 +1,23 @@
 import { useContext } from "react";
 import { useGetIdentity, useGetLocale, useSetLocale } from "@refinedev/core";
-import { Layout as AntdLayout, Space, Avatar, Typography, Switch, Menu, Button, Dropdown } from "antd";
-import { DownOutlined } from '@ant-design/icons';
+import {
+    Layout as AntdLayout,
+    Space,
+    Avatar,
+    Typography,
+    Switch,
+    Menu,
+    Button,
+    Dropdown,
+    theme,
+} from "antd";
+import { DownOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 
 import { ColorModeContext } from "../../contexts/color-mode";
 
 const { Text } = Typography;
+const { useToken } = theme;
 
 type IUser = {
     id: number;
@@ -15,6 +26,7 @@ type IUser = {
 };
 
 export const Header: React.FC = () => {
+    const { token } = useToken();
     const { i18n } = useTranslation();
     const locale = useGetLocale();
     const changeLanguage = useSetLocale();
@@ -27,15 +39,18 @@ export const Header: React.FC = () => {
         <Menu selectedKeys={currentLocale ? [currentLocale] : []}>
             {[...(i18n.languages || [])].sort().map((lang: string) => (
                 <Menu.Item
-                key={lang}
-                onClick={() => changeLanguage(lang)}
-                icon={
-                    <span style={{ marginRight: 8 }}>
-                    <Avatar size={16} src={`/images/flags/${lang}.svg`} />
-                    </span>
-                }
+                    key={lang}
+                    onClick={() => changeLanguage(lang)}
+                    icon={
+                        <span style={{ marginRight: 8 }}>
+                            <Avatar
+                                size={16}
+                                src={`/images/flags/${lang}.svg`}
+                            />
+                        </span>
+                    }
                 >
-                {lang === "en" ? "English" : "German"}
+                    {lang === "en" ? "English" : "German"}
                 </Menu.Item>
             ))}
         </Menu>
@@ -44,9 +59,9 @@ export const Header: React.FC = () => {
     return (
         <AntdLayout.Header
             style={{
+                backgroundColor: token.colorBgElevated,
                 display: "flex",
                 justifyContent: "flex-end",
-
                 alignItems: "center",
                 padding: "0px 24px",
                 height: "64px",
@@ -55,11 +70,14 @@ export const Header: React.FC = () => {
             <Space>
                 <Dropdown overlay={menu}>
                     <Button type="link">
-                    <Space>
-                        <Avatar size={16} src={`/images/flags/${currentLocale}.svg`} />
-                        {currentLocale === "en" ? "English" : "German"}
-                        <DownOutlined />
-                    </Space>
+                        <Space>
+                            <Avatar
+                                size={16}
+                                src={`/images/flags/${currentLocale}.svg`}
+                            />
+                            {currentLocale === "en" ? "English" : "German"}
+                            <DownOutlined />
+                        </Space>
                     </Button>
                 </Dropdown>
                 <Switch
@@ -70,8 +88,8 @@ export const Header: React.FC = () => {
                     }
                     defaultChecked={mode === "dark"}
                 />
-                <Space style={{ marginLeft: "8px" }}>
-                    {user?.name && <Text style={{ color: "white" }} strong>{user.name}</Text>}
+                <Space style={{ marginLeft: "8px" }} size="middle">
+                    {user?.name && <Text strong>{user.name}</Text>}
                     {user?.avatar && (
                         <Avatar src={user?.avatar} alt={user?.name} />
                     )}

--- a/refine-react/plugins/i18n-chakra/src/components/header/index.tsx
+++ b/refine-react/plugins/i18n-chakra/src/components/header/index.tsx
@@ -1,100 +1,159 @@
-  import { 
-    useGetIdentity,
-    useGetLocale,
-    useSetLocale,
-  } from "@refinedev/core";
-  import { 
-    Box,
-    IconButton,
-    HStack,
-    Text,
+import {
     Avatar,
+    Box,
+    HStack,
     Icon,
+    IconButton,
+    Text,
+    useColorMode,
+    useColorModeValue,
     Menu,
     MenuButton,
     MenuItem,
     MenuList,
-    useColorMode,
-  } from "@chakra-ui/react";
-  import { IconMoon, IconSun, IconLanguage } from "@tabler/icons";
+} from "@chakra-ui/react";
+import { RefineThemedLayoutHeaderProps } from "@refinedev/chakra-ui";
+import { useGetIdentity, useGetLocale, useSetLocale } from "@refinedev/core";
+import {
+    IconLayoutSidebarLeftCollapse,
+    IconLayoutSidebarLeftExpand,
+    IconMoon,
+    IconSun,
+    IconLanguage,
+} from "@tabler/icons";
 
-  import i18n from "i18n";
-  
-  type IUser = {
+import i18n from "i18n";
+
+type IUser = {
     id: number;
     name: string;
     avatar: string;
 };
 
-  export const Header: React.FC = () => {
+export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
+    isSiderOpen,
+    onToggleSiderClick,
+    toggleSiderIcon: toggleSiderIconFromProps,
+}) => {
     const { data: user } = useGetIdentity<IUser>();
-    const showUserInfo = user && (user.name || user.avatar);
-  
+
     const { colorMode, toggleColorMode } = useColorMode();
+
+    const bgColor = useColorModeValue(
+        "refine.header.bg.light",
+        "refine.header.bg.dark",
+    );
 
     const changeLanguage = useSetLocale();
     const locale = useGetLocale();
     const currentLocale = locale();
-  
-    return (
-      <Box
-          py="2"
-          px="4"
-          display="flex"
-          justifyContent="flex-end"
-          gap={2}
-          w="full"
-          bg="chakra-body-bg"
-      >
-          <Menu>
-              <MenuButton
-                  as={IconButton}
-                  aria-label="Options"
-                  icon={<IconLanguage />}
-                  variant="ghost"
-              />
-              <MenuList>
-                  {[...(i18n.languages ?? [])].sort().map((lang: string) => (
-                    <MenuItem
-                      key={lang}
-                      onClick={() => {
-                        changeLanguage(lang);
-                      }}
-                      value={lang}
-                      color={lang === currentLocale ? "green" : undefined}
-                      icon={
-                        <Avatar
-                          src={`/images/flags/${lang}.svg`}
-                          h={18}
-                          w={18}
-                        />
-                      }
-                    >
-                      {lang === "en" ? "English" : "German"}
-                    </MenuItem>
-                  ))}
-              </MenuList>
-          </Menu>
-          <IconButton
-              variant="ghost"
-              aria-label="Toggle theme"
-              onClick={toggleColorMode}
-          >
-              <Icon
-                  as={colorMode === "light" ? IconMoon : IconSun}
-                  w="24px"
-                  h="24px"
-              />
-          </IconButton>
 
-          {showUserInfo && (
+    const hasSidebarToggle = Boolean(onToggleSiderClick);
+
+    return (
+        <Box
+            py="2"
+            pr="4"
+            pl="2"
+            display="flex"
+            alignItems="center"
+            justifyContent={
+                hasSidebarToggle
+                    ? { base: "flex-end", md: "space-between" }
+                    : "flex-end"
+            }
+            w="full"
+            height="64px"
+            bg={bgColor}
+            borderBottom="1px"
+            borderBottomColor={useColorModeValue("gray.200", "gray.700")}
+        >
+            {hasSidebarToggle && (
+                <IconButton
+                    display={{ base: "none", md: "flex" }}
+                    backgroundColor="transparent"
+                    aria-label="sidebar-toggle"
+                    onClick={() => onToggleSiderClick?.()}
+                >
+                    {toggleSiderIconFromProps?.(Boolean(isSiderOpen)) ??
+                        (isSiderOpen ? (
+                            <Icon
+                                as={IconLayoutSidebarLeftCollapse}
+                                boxSize={"24px"}
+                            />
+                        ) : (
+                            <Icon
+                                as={IconLayoutSidebarLeftExpand}
+                                boxSize={"24px"}
+                            />
+                        ))}
+                </IconButton>
+            )}
+
             <HStack>
-                <Text size="sm" fontWeight="bold">
-                    {user?.name}
-                </Text>
-                <Avatar size="sm" name={user?.name} src={user?.avatar} />
+                <Menu>
+                    <MenuButton
+                        as={IconButton}
+                        aria-label="Options"
+                        icon={<IconLanguage />}
+                        variant="ghost"
+                    />
+                    <MenuList>
+                        {[...(i18n.languages ?? [])]
+                            .sort()
+                            .map((lang: string) => (
+                                <MenuItem
+                                    key={lang}
+                                    onClick={() => {
+                                        changeLanguage(lang);
+                                    }}
+                                    value={lang}
+                                    color={
+                                        lang === currentLocale
+                                            ? "green"
+                                            : undefined
+                                    }
+                                    icon={
+                                        <Avatar
+                                            src={`/images/flags/${lang}.svg`}
+                                            h={18}
+                                            w={18}
+                                        />
+                                    }
+                                >
+                                    {lang === "en" ? "English" : "German"}
+                                </MenuItem>
+                            ))}
+                    </MenuList>
+                </Menu>
+
+                <IconButton
+                    variant="ghost"
+                    aria-label="Toggle theme"
+                    onClick={toggleColorMode}
+                >
+                    <Icon
+                        as={colorMode === "light" ? IconMoon : IconSun}
+                        w="24px"
+                        h="24px"
+                    />
+                </IconButton>
+
+                {(user?.avatar || user?.name) && (
+                    <HStack>
+                        {user?.name && (
+                            <Text size="sm" fontWeight="bold">
+                                {user.name}
+                            </Text>
+                        )}
+                        <Avatar
+                            size="sm"
+                            name={user?.name}
+                            src={user?.avatar}
+                        />
+                    </HStack>
+                )}
             </HStack>
-          )}
-      </Box>
-  );
-  };    
+        </Box>
+    );
+};

--- a/refine-react/plugins/i18n-mantine/src/components/header/index.tsx
+++ b/refine-react/plugins/i18n-mantine/src/components/header/index.tsx
@@ -1,17 +1,13 @@
-
+import { useGetIdentity, useGetLocale, useSetLocale } from "@refinedev/core";
 import {
-  useGetIdentity,
-  useGetLocale,
-  useSetLocale,
-} from "@refinedev/core";
-import {
-  ActionIcon,
-  Group,
-  Header as MantineHeader,
-  Title,
-  Avatar,
-  useMantineColorScheme,
-  Menu,
+    ActionIcon,
+    Avatar,
+    Group,
+    Header as MantineHeader,
+    Title,
+    useMantineColorScheme,
+    useMantineTheme,
+    Menu,
 } from "@mantine/core";
 import { IconSun, IconMoonStars, IconLanguage } from "@tabler/icons";
 
@@ -24,63 +20,92 @@ type IUser = {
 };
 
 export const Header: React.FC = () => {
-  const { data: user } = useGetIdentity<IUser>();
-  const showUserInfo = user && (user.name || user.avatar);
+    const { data: user } = useGetIdentity<IUser>();
 
-  const { colorScheme, toggleColorScheme } = useMantineColorScheme();
-  const dark = colorScheme === "dark";
+    const changeLanguage = useSetLocale();
+    const locale = useGetLocale();
+    const currentLocale = locale();
 
-  const changeLanguage = useSetLocale();
-  const locale = useGetLocale();
-  const currentLocale = locale();
+    const theme = useMantineTheme();
 
-  return (
-    <MantineHeader height={50} p="xs">
-      <Group position="right">
-        <Menu shadow="md">
-          <Menu.Target>
-            <ActionIcon variant="outline">
-              <IconLanguage size={18} />
-            </ActionIcon>
-          </Menu.Target>
+    const { colorScheme, toggleColorScheme } = useMantineColorScheme();
+    const dark = colorScheme === "dark";
 
-          <Menu.Dropdown>
-            {[...(i18n.languages ?? [])].sort().map((lang: string) => (
-              <Menu.Item
-                key={lang}
-                onClick={() => {
-                  changeLanguage(lang);
-                }}
-                value={lang}
-                color={lang === currentLocale ? "primary" : undefined}
-                icon={
-                  <Avatar
-                    src={`/images/flags/${lang}.svg`}
-                    size={18}
-                    radius="lg"
-                  />
-                }
-              >
-                {lang === "en" ? "English" : "German"}
-              </Menu.Item>
-            ))}
-          </Menu.Dropdown>
-        </Menu>
-        <ActionIcon
-          variant="outline"
-          color={dark ? "yellow" : "primary"}
-          onClick={() => toggleColorScheme()}
-          title="Toggle color scheme"
+    const borderColor = dark ? theme.colors.dark[6] : theme.colors.gray[2];
+
+    return (
+        <MantineHeader
+            zIndex={199}
+            height={64}
+            py={6}
+            px="sm"
+            sx={{
+                borderBottom: `1px solid ${borderColor}`,
+            }}
         >
-          {dark ? <IconSun size={18} /> : <IconMoonStars size={18} />}
-        </ActionIcon>
-        {showUserInfo && (
-          <Group spacing="xs">
-            <Title order={6}>{user?.name}</Title>
-            <Avatar src={user?.avatar} alt={user?.name} radius="xl" />
-          </Group>
-        )}
-      </Group>
-    </MantineHeader>
-  );
-};      
+            <Group
+                position="right"
+                align="center"
+                sx={{
+                    height: "100%",
+                }}
+            >
+                <Menu shadow="md">
+                    <Menu.Target>
+                        <ActionIcon variant="outline">
+                            <IconLanguage size={18} />
+                        </ActionIcon>
+                    </Menu.Target>
+
+                    <Menu.Dropdown>
+                        {[...(i18n.languages ?? [])]
+                            .sort()
+                            .map((lang: string) => (
+                                <Menu.Item
+                                    key={lang}
+                                    onClick={() => {
+                                        changeLanguage(lang);
+                                    }}
+                                    value={lang}
+                                    color={
+                                        lang === currentLocale
+                                            ? "primary"
+                                            : undefined
+                                    }
+                                    icon={
+                                        <Avatar
+                                            src={`/images/flags/${lang}.svg`}
+                                            size={18}
+                                            radius="lg"
+                                        />
+                                    }
+                                >
+                                    {lang === "en" ? "English" : "German"}
+                                </Menu.Item>
+                            ))}
+                    </Menu.Dropdown>
+                </Menu>
+
+                <ActionIcon
+                    variant="outline"
+                    color={dark ? "yellow" : "primary"}
+                    onClick={() => toggleColorScheme()}
+                    title="Toggle color scheme"
+                >
+                    {dark ? <IconSun size={18} /> : <IconMoonStars size={18} />}
+                </ActionIcon>
+
+                {(user?.name || user?.avatar) && (
+                    <Group spacing="xs">
+                        {user?.name && <Title order={6}>{user?.name}</Title>}
+                        <Avatar
+                            src={user?.avatar}
+                            alt={user?.name}
+                            radius="xl"
+                        />
+                    </Group>
+                )}
+            </Group>
+        </MantineHeader>
+    );
+};

--- a/refine-react/plugins/i18n-mui/src/components/header/index.tsx
+++ b/refine-react/plugins/i18n-mui/src/components/header/index.tsx
@@ -1,21 +1,19 @@
 import React, { useContext } from "react";
+import { useGetIdentity, useGetLocale, useSetLocale } from "@refinedev/core";
+import { RefineThemedLayoutHeaderProps } from "@refinedev/mui";
+import { DarkModeOutlined, LightModeOutlined, Menu } from "@mui/icons-material";
 import {
-  useGetIdentity,
-  useGetLocale,
-  useSetLocale,
-} from "@refinedev/core";
-import {
-  AppBar,
-  IconButton,
-  Avatar,
-  Stack,
-  FormControl,
-  MenuItem,
-  Select,
-  Toolbar,
-  Typography,
+    AppBar,
+    Avatar,
+    IconButton,
+    Stack,
+    Toolbar,
+    Typography,
+    FormControl,
+    MenuItem,
+    Select,
 } from "@mui/material";
-import { DarkModeOutlined, LightModeOutlined } from "@mui/icons-material";
+
 import i18n from "i18n";
 
 import { ColorModeContext } from "../../contexts/color-mode";
@@ -26,80 +24,120 @@ type IUser = {
     avatar: string;
 };
 
-export const Header: React.FC = () => {
+export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
+    isSiderOpen,
+    onToggleSiderClick,
+    toggleSiderIcon: toggleSiderIconFromProps,
+}) => {
+    const { mode, setMode } = useContext(ColorModeContext);
 
-  const { mode, setMode } = useContext(ColorModeContext);
+    const { data: user } = useGetIdentity<IUser>();
 
-  const changeLanguage = useSetLocale();
-  const locale = useGetLocale();
-  const currentLocale = locale();
+    const changeLanguage = useSetLocale();
+    const locale = useGetLocale();
+    const currentLocale = locale();
 
-  const { data: user } = useGetIdentity<IUser>();
-  const showUserInfo = user && (user.name || user.avatar);
+    const hasSidebarToggle = Boolean(onToggleSiderClick);
 
-  return (
-    <AppBar color="default" position="sticky" elevation={1}>
-      <Toolbar>
-        <Stack
-          direction="row"
-          width="100%"
-          justifyContent="flex-end"
-          alignItems="center"
-        >
-          <IconButton
-            onClick={() => {
-              setMode();
-            }}
-          >
-            {mode === "dark" ? <LightModeOutlined /> : <DarkModeOutlined />}
-          </IconButton>
+    return (
+        <AppBar color="default" position="sticky">
+            <Toolbar>
+                <Stack direction="row" width="100%" alignItems="center">
+                    {hasSidebarToggle && (
+                        <IconButton
+                            aria-label="open drawer"
+                            onClick={() => onToggleSiderClick?.()}
+                            edge="start"
+                            sx={{
+                                mr: 2,
+                                display: { xs: "none", md: "flex" },
+                                ...(isSiderOpen && { display: "none" }),
+                            }}
+                        >
+                            {toggleSiderIconFromProps?.(
+                                Boolean(isSiderOpen),
+                            ) ?? <Menu />}
+                        </IconButton>
+                    )}
 
-          <FormControl sx={{ m: 1, minWidth: 120 }}>
-            <Select
-              disableUnderline
-              defaultValue={currentLocale}
-              inputProps={{ "aria-label": "Without label" }}
-              variant="standard"
-            >
-              {[...(i18n.languages ?? [])].sort().map((lang: string) => (
-                <MenuItem
-                  selected={currentLocale === lang}
-                  key={lang}
-                  defaultValue={lang}
-                  onClick={() => {
-                    changeLanguage(lang);
-                  }}
-                  value={lang}
-                >
-                  <Stack
-                    direction="row"
-                    alignItems="center"
-                    justifyContent="center"
-                  >
-                    <Avatar
-                      sx={{
-                        width: "16px",
-                        height: "16px",
-                        marginRight: "5px",
-                      }}
-                      src={`/images/flags/${lang}.svg`}
-                    />
-                    {lang === "en" ? "English" : "German"}
-                  </Stack>
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          {showUserInfo && (
-            <Stack direction="row" gap="16px" alignItems="center">
-              {user.avatar && <Avatar src={user?.avatar} alt={user?.name} />}
-              {user.name && (
-                <Typography variant="subtitle2">{user?.name}</Typography>
-              )}
-            </Stack>
-          )}
-        </Stack>
-      </Toolbar>
-    </AppBar>
-  );
+                    <Stack
+                        direction="row"
+                        width="100%"
+                        justifyContent="flex-end"
+                        alignItems="center"
+                        gap="16px"
+                    >
+                        <FormControl sx={{ minWidth: 120 }}>
+                            <Select
+                                disableUnderline
+                                defaultValue={currentLocale}
+                                inputProps={{ "aria-label": "Without label" }}
+                                variant="standard"
+                            >
+                                {[...(i18n.languages ?? [])]
+                                    .sort()
+                                    .map((lang: string) => (
+                                        <MenuItem
+                                            selected={currentLocale === lang}
+                                            key={lang}
+                                            defaultValue={lang}
+                                            onClick={() => {
+                                                changeLanguage(lang);
+                                            }}
+                                            value={lang}
+                                        >
+                                            <Stack
+                                                direction="row"
+                                                alignItems="center"
+                                                justifyContent="center"
+                                            >
+                                                <Avatar
+                                                    sx={{
+                                                        width: "16px",
+                                                        height: "16px",
+                                                        marginRight: "5px",
+                                                    }}
+                                                    src={`/images/flags/${lang}.svg`}
+                                                />
+                                                {lang === "en"
+                                                    ? "English"
+                                                    : "German"}
+                                            </Stack>
+                                        </MenuItem>
+                                    ))}
+                            </Select>
+                        </FormControl>
+
+                        <IconButton
+                            onClick={() => {
+                                setMode();
+                            }}
+                        >
+                            {mode === "dark" ? (
+                                <LightModeOutlined />
+                            ) : (
+                                <DarkModeOutlined />
+                            )}
+                        </IconButton>
+
+                        {(user?.avatar || user?.name) && (
+                            <Stack
+                                direction="row"
+                                gap="16px"
+                                alignItems="center"
+                                justifyContent="center"
+                            >
+                                {user?.name && (
+                                    <Typography variant="subtitle2">
+                                        {user?.name}
+                                    </Typography>
+                                )}
+                                <Avatar src={user?.avatar} alt={user?.name} />
+                            </Stack>
+                        )}
+                    </Stack>
+                </Stack>
+            </Toolbar>
+        </AppBar>
+    );
 };

--- a/refine-react/plugins/mantine/extend.js
+++ b/refine-react/plugins/mantine/extend.js
@@ -18,6 +18,10 @@ const base = {
                 "</ColorSchemeProvider>",
             ],
             [
+                "{/* You can change the theme colors here. example: theme={{ ...RefineThemes.Magenta, colorScheme:colorScheme }} */}",
+                "",
+            ],
+            [
                 `<MantineProvider theme={{ ...RefineThemes.Blue, colorScheme:colorScheme }} withNormalizeCSS withGlobalStyles>`,
                 "</MantineProvider>",
             ],

--- a/refine-react/plugins/mantine/extend.js
+++ b/refine-react/plugins/mantine/extend.js
@@ -4,35 +4,44 @@ const base = {
         import: [
             `import { MantineProvider, Global, ColorSchemeProvider, ColorScheme } from "@mantine/core";`,
             `import { NotificationsProvider } from "@mantine/notifications";`,
-            `import { useLocalStorage } from "@mantine/hooks";`
+            `import { useLocalStorage } from "@mantine/hooks";`,
         ],
         refineMantineImports: [
             "notificationProvider",
-            "LightTheme",
-            "DarkTheme",
-            "Layout",
+            "RefineThemes",
+            "ThemedLayout",
             "ErrorComponent",
         ],
         wrapper: [
-            ["<ColorSchemeProvider colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}>", "</ColorSchemeProvider>"],
-            [`<MantineProvider theme={colorScheme === "dark" ? DarkTheme : LightTheme} withNormalizeCSS withGlobalStyles>`, "</MantineProvider>"],
-            [`<Global styles={{ body: { WebkitFontSmoothing: "auto" } }} />`, ``],
-            [`<NotificationsProvider position="top-right">`, `</NotificationsProvider>`],
+            [
+                "<ColorSchemeProvider colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}>",
+                "</ColorSchemeProvider>",
+            ],
+            [
+                `<MantineProvider theme={{ ...RefineThemes.Blue, colorScheme:colorScheme }} withNormalizeCSS withGlobalStyles>`,
+                "</MantineProvider>",
+            ],
+            [
+                `<Global styles={{ body: { WebkitFontSmoothing: "auto" } }} />`,
+                ``,
+            ],
+            [
+                `<NotificationsProvider position="top-right">`,
+                `</NotificationsProvider>`,
+            ],
         ],
         innerHooks: [
             `const [colorScheme, setColorScheme] = useLocalStorage<ColorScheme>({
                 key: "mantine-color-scheme",
                 defaultValue: "light",
                 getInitialValueInEffect: true,
-            });`
+            });`,
         ],
         inner: [
             `const toggleColorScheme = (value?: ColorScheme) =>
-                setColorScheme(value || (colorScheme === "dark" ? "light" : "dark"));`
+                setColorScheme(value || (colorScheme === "dark" ? "light" : "dark"));`,
         ],
-        localImport: [
-            `import { Header } from "./components/header";`
-        ],
+        localImport: [`import { Header } from "./components/header";`],
     },
 };
 

--- a/refine-react/plugins/mantine/src/components/header/index.tsx
+++ b/refine-react/plugins/mantine/src/components/header/index.tsx
@@ -1,11 +1,12 @@
 import { useGetIdentity } from "@refinedev/core";
 import {
-  ActionIcon,
-  Group,
-  Header as MantineHeader,
-  Title,
-  Avatar,
-  useMantineColorScheme,
+    ActionIcon,
+    Group,
+    Header as MantineHeader,
+    Title,
+    Avatar,
+    useMantineColorScheme,
+    useMantineTheme,
 } from "@mantine/core";
 import { IconSun, IconMoonStars } from "@tabler/icons";
 
@@ -16,30 +17,51 @@ type IUser = {
 };
 
 export const Header: React.FC = () => {
-  const { data: user } = useGetIdentity<IUser>();
-  const showUserInfo = user && (user.name || user.avatar);
+    const { data: user } = useGetIdentity<IUser>();
 
-  const { colorScheme, toggleColorScheme } = useMantineColorScheme();
-  const dark = colorScheme === "dark";
+    const theme = useMantineTheme();
 
-  return (
-      <MantineHeader height={50} p="xs">
-          <Group position="right">
-              <ActionIcon
-                  variant="outline"
-                  color={dark ? "yellow" : "primary"}
-                  onClick={() => toggleColorScheme()}
-                  title="Toggle color scheme"
-              >
-                  {dark ? <IconSun size={18} /> : <IconMoonStars size={18} />}
-              </ActionIcon>
-              {showUserInfo && (
-                <Group spacing="xs">
-                    <Title order={6}>{user?.name}</Title>
-                    <Avatar src={user?.avatar} alt={user?.name} radius="xl" />
-                </Group>
-              )}
-          </Group>
-      </MantineHeader>
-  );
+    const { colorScheme, toggleColorScheme } = useMantineColorScheme();
+    const dark = colorScheme === "dark";
+
+    const borderColor = dark ? theme.colors.dark[6] : theme.colors.gray[2];
+
+    return (
+        <MantineHeader
+            zIndex={199}
+            height={64}
+            py={6}
+            px="sm"
+            sx={{
+                borderBottom: `1px solid ${borderColor}`,
+            }}
+        >
+            <Group
+                position="right"
+                align="center"
+                sx={{
+                    height: "100%",
+                }}
+            >
+                <ActionIcon
+                    variant="outline"
+                    color={dark ? "yellow" : "primary"}
+                    onClick={() => toggleColorScheme()}
+                    title="Toggle color scheme"
+                >
+                    {dark ? <IconSun size={18} /> : <IconMoonStars size={18} />}
+                </ActionIcon>
+                {(user?.name || user?.avatar) && (
+                    <Group spacing="xs">
+                        {user?.name && <Title order={6}>{user?.name}</Title>}
+                        <Avatar
+                            src={user?.avatar}
+                            alt={user?.name}
+                            radius="xl"
+                        />
+                    </Group>
+                )}
+            </Group>
+        </MantineHeader>
+    );
 };

--- a/refine-react/plugins/mui/extend.js
+++ b/refine-react/plugins/mui/extend.js
@@ -1,25 +1,25 @@
 const base = {
     _app: {
         refineProps: ["notificationProvider={notificationProvider}"],
-        import: [
-            `import { CssBaseline, GlobalStyles } from "@mui/material";`,
-        ],
+        import: [`import { CssBaseline, GlobalStyles } from "@mui/material";`],
         refineMuiImports: [
             "notificationProvider",
             "RefineSnackbarProvider",
-            "Layout",
-            "ErrorComponent"
+            "ThemedLayout",
+            "ErrorComponent",
         ],
         localImport: [
             `import { ColorModeContextProvider } from "./contexts/color-mode";`,
-            `import { Header } from "./components/header";`
+            `import { Header } from "./components/header";`,
         ],
         wrapper: [
             ["<ColorModeContextProvider>", "</ColorModeContextProvider>"],
             [`<CssBaseline />`, ``],
-            [`<GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />`, ``],
-            [`<RefineSnackbarProvider>`, `</RefineSnackbarProvider>`]
-
+            [
+                `<GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />`,
+                ``,
+            ],
+            [`<RefineSnackbarProvider>`, `</RefineSnackbarProvider>`],
         ],
     },
 };

--- a/refine-react/plugins/mui/src/components/header/index.tsx
+++ b/refine-react/plugins/mui/src/components/header/index.tsx
@@ -1,14 +1,15 @@
 import React, { useContext } from "react";
 import { useGetIdentity } from "@refinedev/core";
 import {
-  AppBar,
-  IconButton,
-  Avatar,
-  Stack,
-  Toolbar,
-  Typography,
+    AppBar,
+    IconButton,
+    Avatar,
+    Stack,
+    Toolbar,
+    Typography,
 } from "@mui/material";
-import { DarkModeOutlined, LightModeOutlined } from "@mui/icons-material";
+import { RefineThemedLayoutHeaderProps } from "@refinedev/mui";
+import { DarkModeOutlined, LightModeOutlined, Menu } from "@mui/icons-material";
 
 import { ColorModeContext } from "../../contexts/color-mode";
 
@@ -18,38 +19,79 @@ type IUser = {
     avatar: string;
 };
 
-export const Header: React.FC = () => {
-  const { mode, setMode } = useContext(ColorModeContext);
+export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
+    isSiderOpen,
+    onToggleSiderClick,
+    toggleSiderIcon: toggleSiderIconFromProps,
+}) => {
+    const { mode, setMode } = useContext(ColorModeContext);
 
-  const { data: user } = useGetIdentity<IUser>();
-  const showUserInfo = user && (user.name || user.avatar);
+    const { data: user } = useGetIdentity<IUser>();
 
-  return (
-    <AppBar color="default" position="sticky" elevation={1}>
-      <Toolbar>
-        <Stack
-            direction="row"
-            width="100%"
-            justifyContent="flex-end"
-            alignItems="center"
-        >
-          <IconButton
-            onClick={() => {
-              setMode();
-            }}
-          >
-            {mode === "dark" ? <LightModeOutlined /> : <DarkModeOutlined />}
-          </IconButton>
-          {showUserInfo && (
-            <Stack direction="row" gap="16px" alignItems="center">
-              {user.avatar && <Avatar src={user?.avatar} alt={user?.name} />}
-              {user.name && (
-                <Typography variant="subtitle2">{user?.name}</Typography>
-              )}
-            </Stack>
-          )}
-        </Stack>
-      </Toolbar>
-    </AppBar>
-  );
+    const hasSidebarToggle = Boolean(onToggleSiderClick);
+
+    return (
+        <AppBar color="default" position="sticky">
+            <Toolbar>
+                <Stack
+                    direction="row"
+                    width="100%"
+                    justifyContent="flex-end"
+                    alignItems="center"
+                >
+                    {hasSidebarToggle && (
+                        <IconButton
+                            aria-label="open drawer"
+                            onClick={() => onToggleSiderClick?.()}
+                            edge="start"
+                            sx={{
+                                mr: 2,
+                                display: { xs: "none", md: "flex" },
+                                ...(isSiderOpen && { display: "none" }),
+                            }}
+                        >
+                            {toggleSiderIconFromProps?.(
+                                Boolean(isSiderOpen),
+                            ) ?? <Menu />}
+                        </IconButton>
+                    )}
+
+                    <Stack
+                        direction="row"
+                        width="100%"
+                        justifyContent="flex-end"
+                        alignItems="center"
+                    >
+                        <IconButton
+                            onClick={() => {
+                                setMode();
+                            }}
+                        >
+                            {mode === "dark" ? (
+                                <LightModeOutlined />
+                            ) : (
+                                <DarkModeOutlined />
+                            )}
+                        </IconButton>
+
+                        {(user?.avatar || user?.name) && (
+                            <Stack
+                                direction="row"
+                                gap="16px"
+                                alignItems="center"
+                                justifyContent="center"
+                            >
+                                {user?.name && (
+                                    <Typography variant="subtitle2">
+                                        {user?.name}
+                                    </Typography>
+                                )}
+                                <Avatar src={user?.avatar} alt={user?.name} />
+                            </Stack>
+                        )}
+                    </Stack>
+                </Stack>
+            </Toolbar>
+        </AppBar>
+    );
 };

--- a/refine-react/plugins/mui/src/contexts/color-mode/index.tsx
+++ b/refine-react/plugins/mui/src/contexts/color-mode/index.tsx
@@ -5,7 +5,7 @@ import React, {
     useState,
 } from "react";
 import { ThemeProvider } from "@mui/material/styles";
-import { DarkTheme, LightTheme } from "@refinedev/mui";
+import { RefineThemes } from "@refinedev/mui";
 
 type ColorModeContextType = {
     mode: string;
@@ -48,7 +48,12 @@ export const ColorModeContextProvider: React.FC<PropsWithChildren> = ({
                 mode,
             }}
         >
-            <ThemeProvider theme={mode === "light" ? LightTheme : DarkTheme}>
+            <ThemeProvider
+                // you can change the theme colors here. example: mode === "light" ? RefineThemes.Magenta : RefineThemes.MagentaDark
+                theme={
+                    mode === "light" ? RefineThemes.Blue : RefineThemes.BlueDark
+                }
+            >
                 {children}
             </ThemeProvider>
         </ColorModeContext.Provider>

--- a/refine-react/template/src/App.tsx
+++ b/refine-react/template/src/App.tsx
@@ -95,9 +95,9 @@ function App() {
                                 <%_ if (answers["ui-framework"] === 'no') { _%>
                                     <Outlet />
                                 <%_ } else { _%>
-                                    <Layout Header={Header}>
+                                    <ThemedLayout Header={Header}>
                                         <Outlet />
-                                    </Layout>
+                                    </ThemedLayout>
                                 <%_ } _%>
                             </Authenticated>
                         }
@@ -141,9 +141,9 @@ function App() {
                                 <%_ if (answers["ui-framework"] === 'no') { _%>
                                     <Outlet />
                                 <%_ } else { _%>
-                                    <Layout Header={Header}>
+                                    <ThemedLayout Header={Header}>
                                         <Outlet />
-                                    </Layout>
+                                    </ThemedLayout>
                                 <%_ } _%>
                             </Authenticated>
                         }
@@ -155,7 +155,7 @@ function App() {
 
                 <%_ if (_app.hasRoutes === true && _app.isNoAuthRoutes) { _%>
                 <Routes>
-                    <Route element={<Layout Header={Header}><Outlet /></Layout>}>
+                    <Route element={<ThemedLayout Header={Header}><Outlet /></ThemedLayout>}>
                         <Route index element={
                             <%_ if (answers["data-provider"] === 'data-provider-strapi-v4') { _%>
                                 <NavigateToResource resource="blog-posts" />
@@ -176,7 +176,7 @@ function App() {
                             <Route path="show/:id" element={<CategoryShow />} />
                         </Route>
                     </Route>
-                    <Route element={<Layout Header={Header}><Outlet /></Layout>}>
+                    <Route element={<ThemedLayout Header={Header}><Outlet /></ThemedLayout>}>
                         <Route path="*" element={<ErrorComponent />} />
                     </Route>
                 </Routes> 


### PR DESCRIPTION
refine-react:

-   [x] antd, i18n-antd:

    -   [x] `<Layout>` updated to `<ThemedLayout>`.
    -   [x] `<Header>` copied from `<ThemedHeader>`.

-   [x] mui, 18n-mui:

    -   [x] `<Layout>` updated to `<ThemedLayout>`.
    -   [x] `<Header>` copied from `<ThemedHeader>`.

-   [x] chakra-ui, i18n-chakra-ui:

    -   [x] `<Layout>` updated to `<ThemedLayout>`.
    -   [x] `<Header>` copied from `<ThemedHeader>`.

-   [x] mantine, i18n-mantine:
    -   [x] `<Layout>` updated to `<ThemedLayout>`.
    -   [x] `<Header>` copied from `<ThemedHeader>`.


