### PR TITLE
feat(refine-nextjs): update layout to themed-layout

### DIFF
--- a/refine-nextjs/plugins/antd/extend.js
+++ b/refine-nextjs/plugins/antd/extend.js
@@ -2,9 +2,9 @@ const base = {
     _app: {
         refineProps: ["notificationProvider={notificationProvider}"],
         import: ['import "@refinedev/antd/dist/reset.css";'],
-        refineAntdImports: ["notificationProvider", "Layout"],
+        refineAntdImports: ["notificationProvider", "ThemedLayout"],
         wrapper: [
-            [`<ColorModeContextProvider>`, `</ColorModeContextProvider>`]
+            [`<ColorModeContextProvider>`, `</ColorModeContextProvider>`],
         ],
         localImport: [
             `import { Header } from "@components/header"`,

--- a/refine-nextjs/plugins/antd/src/components/header/index.tsx
+++ b/refine-nextjs/plugins/antd/src/components/header/index.tsx
@@ -1,49 +1,56 @@
 import { useContext } from "react";
 import { useGetIdentity } from "@refinedev/core";
 import {
-  Layout as AntdLayout,
-  Space,
-  Avatar,
-  Typography,
-  Switch,
+    Layout as AntdLayout,
+    Space,
+    Avatar,
+    Typography,
+    Switch,
+    theme,
 } from "antd";
-import { ColorModeContext } from "@contexts";
+import { ColorModeContext } from "../../contexts";
 
 const { Text } = Typography;
+const { useToken } = theme;
 
- interface IUser {
+type IUser = {
+    id: number;
     name: string;
     avatar: string;
-  }
+};
 
 export const Header: React.FC = () => {
-  const { data: user } = useGetIdentity<IUser>();
-  const { mode, setMode } = useContext(ColorModeContext);
+    const { token } = useToken();
+    const { data: user } = useGetIdentity<IUser>();
+    const { mode, setMode } = useContext(ColorModeContext);
 
-  return (
-    <AntdLayout.Header
-      style={{
-        display: "flex",
-        justifyContent: "flex-end",
-        alignItems: "center",
-        padding: "0px 24px",
-        height: "64px",
-      }}
-    >
-      <Switch
-        checkedChildren="🌛"
-        unCheckedChildren="🔆"
-        onChange={() => setMode(mode === "light" ? "dark" : "light")}
-        defaultChecked={mode === "dark"}
-      />
-      <Space style={{ marginLeft: "8px" }}>
-        {user?.name && (
-          <Text style={{ color: "white" }} strong>
-            {user.name}
-          </Text>
-        )}
-        {user?.avatar && <Avatar src={user?.avatar} alt={user?.name} />}
-      </Space>
-    </AntdLayout.Header>
-  );
+    return (
+        <AntdLayout.Header
+            style={{
+                backgroundColor: token.colorBgElevated,
+                display: "flex",
+                justifyContent: "flex-end",
+                alignItems: "center",
+                padding: "0px 24px",
+                height: "64px",
+            }}
+        >
+            <Space>
+                <Switch
+                    checkedChildren="🌛"
+                    unCheckedChildren="🔆"
+                    onChange={() =>
+                        setMode(mode === "light" ? "dark" : "light")
+                    }
+                    defaultChecked={mode === "dark"}
+                />
+                <Space style={{ marginLeft: "8px" }} size="middle">
+                    {user?.name && <Text strong>{user.name}</Text>}
+                    {user?.avatar && (
+                        <Avatar src={user?.avatar} alt={user?.name} />
+                    )}
+                </Space>
+            </Space>
+        </AntdLayout.Header>
+    );
 };

--- a/refine-nextjs/plugins/antd/src/contexts/index.tsx
+++ b/refine-nextjs/plugins/antd/src/contexts/index.tsx
@@ -1,61 +1,65 @@
 import React, {
-  PropsWithChildren,
-  createContext,
-  useEffect,
-  useState,
+    PropsWithChildren,
+    createContext,
+    useEffect,
+    useState,
 } from "react";
+import { RefineThemes } from "@refinedev/antd";
 import { ConfigProvider, theme } from "antd";
 import { parseCookies } from "nookies";
 
 type ColorModeContextType = {
-  mode: string;
-  setMode: (mode: string) => void;
+    mode: string;
+    setMode: (mode: string) => void;
 };
 
 export const ColorModeContext = createContext<ColorModeContextType>(
-  {} as ColorModeContextType
+    {} as ColorModeContextType,
 );
 
 export const ColorModeContextProvider: React.FC<PropsWithChildren> = ({
-  children,
+    children,
 }) => {
-  const [isMounted, setIsMounted] = useState(false);
-  const [mode, setMode] = useState("light");
+    const [isMounted, setIsMounted] = useState(false);
+    const [mode, setMode] = useState("light");
 
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
+    useEffect(() => {
+        setIsMounted(true);
+    }, []);
 
-  useEffect(() => {
-    if (isMounted) {
-      setMode(parseCookies()["theme"]);
-    }
-  }, [isMounted]);
+    useEffect(() => {
+        if (isMounted) {
+            setMode(parseCookies()["theme"]);
+        }
+    }, [isMounted]);
 
-  const setColorMode = () => {
-    if (mode === "light") {
-      setMode("dark");
-    } else {
-      setMode("light");
-    }
-  };
+    const setColorMode = () => {
+        if (mode === "light") {
+            setMode("dark");
+        } else {
+            setMode("light");
+        }
+    };
 
-  const { darkAlgorithm, defaultAlgorithm } = theme;
+    const { darkAlgorithm, defaultAlgorithm } = theme;
 
-  return (
-    <ColorModeContext.Provider
-      value={{
-        setMode: setColorMode,
-        mode,
-      }}
-    >
-      <ConfigProvider
-        theme={{
-          algorithm: mode === "light" ? defaultAlgorithm : darkAlgorithm,
-        }}
-      >
-        {children}
-      </ConfigProvider>
-    </ColorModeContext.Provider>
-  );
+    return (
+        <ColorModeContext.Provider
+            value={{
+                setMode: setColorMode,
+                mode,
+            }}
+        >
+            <ConfigProvider
+                // you can change the theme colors here. example: ...RefineThemes.Magenta,
+                theme={{
+                    ...RefineThemes.Blue,
+                    algorithm:
+                        mode === "light" ? defaultAlgorithm : darkAlgorithm,
+                }}
+            >
+                {children}
+            </ConfigProvider>
+        </ColorModeContext.Provider>
+    );
 };

--- a/refine-nextjs/plugins/chakra/extend.js
+++ b/refine-nextjs/plugins/chakra/extend.js
@@ -1,22 +1,20 @@
 const base = {
     _app: {
-        refineProps: [
-            "notificationProvider={notificationProvider}",
-        ],
-        import: [
-            `import { ChakraProvider } from "@chakra-ui/react";`,
-        ],
+        refineProps: ["notificationProvider={notificationProvider}"],
+        import: [`import { ChakraProvider } from "@chakra-ui/react";`],
         refineChakraImports: [
             "notificationProvider",
-            "refineTheme",
-            "Layout"
+            "RefineThemes",
+            "ThemedLayout",
         ],
         wrapper: [
-            [`<ChakraProvider theme={refineTheme}>`, "</ChakraProvider>"],
+            [
+                "{/* You can change the theme colors here. example: theme={RefineThemes.Magenta} */}",
+                "",
+            ],
+            [`<ChakraProvider theme={RefineThemes.Blue}>`, "</ChakraProvider>"],
         ],
-        localImport: [
-            `import { Header } from "@components/header"`,
-        ],
+        localImport: [`import { Header } from "@components/header"`],
     },
 };
 

--- a/refine-nextjs/plugins/chakra/src/components/header/index.tsx
+++ b/refine-nextjs/plugins/chakra/src/components/header/index.tsx
@@ -1,47 +1,111 @@
 import { useGetIdentity } from "@refinedev/core";
-import { Box, IconButton, HStack, Text, Avatar, Icon, useColorMode } from "@chakra-ui/react";
-import { IconMoon, IconSun } from "@tabler/icons";
+import {
+    Box,
+    IconButton,
+    HStack,
+    Text,
+    Avatar,
+    Icon,
+    useColorMode,
+    useColorModeValue,
+} from "@chakra-ui/react";
+import { RefineThemedLayoutHeaderProps } from "@refinedev/chakra-ui";
+import {
+    IconMoon,
+    IconSun,
+    IconLayoutSidebarLeftCollapse,
+    IconLayoutSidebarLeftExpand,
+} from "@tabler/icons";
 
- interface IUser {
+type IUser = {
+    id: number;
     name: string;
     avatar: string;
-  }
+};
 
-export const Header: React.FC = () => {
-  const { data: user } = useGetIdentity<IUser>();
-  const showUserInfo = user && (user.name || user.avatar);
+export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
+    isSiderOpen,
+    onToggleSiderClick,
+    toggleSiderIcon: toggleSiderIconFromProps,
+}) => {
+    const { data: user } = useGetIdentity<IUser>();
 
-  const { colorMode, toggleColorMode } = useColorMode();
+    const { colorMode, toggleColorMode } = useColorMode();
 
-  return (
-    <Box
-        py="2"
-        px="4"
-        display="flex"
-        justifyContent="flex-end"
-        gap={2}
-        w="full"
-        bg="chakra-body-bg"
-    >
-        <IconButton
-            variant="ghost"
-            aria-label="Toggle theme"
-            onClick={toggleColorMode}
+    const bgColor = useColorModeValue(
+        "refine.header.bg.light",
+        "refine.header.bg.dark",
+    );
+
+    const hasSidebarToggle = Boolean(onToggleSiderClick);
+
+    return (
+        <Box
+            py="2"
+            pr="4"
+            pl="2"
+            display="flex"
+            alignItems="center"
+            justifyContent={
+                hasSidebarToggle
+                    ? { base: "flex-end", md: "space-between" }
+                    : "flex-end"
+            }
+            w="full"
+            height="64px"
+            bg={bgColor}
+            borderBottom="1px"
+            borderBottomColor={useColorModeValue("gray.200", "gray.700")}
         >
-            <Icon
-                as={colorMode === "light" ? IconMoon : IconSun}
-                w="24px"
-                h="24px"
-            />
-        </IconButton>
-        {showUserInfo && (
-          <HStack>
-            <Text size="sm" fontWeight="bold">
-                {user?.name}
-            </Text>
-            <Avatar size="sm" name={user?.name} src={user?.avatar} />
-          </HStack>
-        )}
-    </Box>
-);
+            {hasSidebarToggle && (
+                <IconButton
+                    display={{ base: "none", md: "flex" }}
+                    backgroundColor="transparent"
+                    aria-label="sidebar-toggle"
+                    onClick={() => onToggleSiderClick?.()}
+                >
+                    {toggleSiderIconFromProps?.(Boolean(isSiderOpen)) ??
+                        (isSiderOpen ? (
+                            <Icon
+                                as={IconLayoutSidebarLeftCollapse}
+                                boxSize={"24px"}
+                            />
+                        ) : (
+                            <Icon
+                                as={IconLayoutSidebarLeftExpand}
+                                boxSize={"24px"}
+                            />
+                        ))}
+                </IconButton>
+            )}
+
+            <HStack>
+                <IconButton
+                    variant="ghost"
+                    aria-label="Toggle theme"
+                    onClick={toggleColorMode}
+                >
+                    <Icon
+                        as={colorMode === "light" ? IconMoon : IconSun}
+                        w="24px"
+                        h="24px"
+                    />
+                </IconButton>
+                {(user?.avatar || user?.name) && (
+                    <HStack>
+                        {user?.name && (
+                            <Text size="sm" fontWeight="bold">
+                                {user.name}
+                            </Text>
+                        )}
+                        <Avatar
+                            size="sm"
+                            name={user?.name}
+                            src={user?.avatar}
+                        />
+                    </HStack>
+                )}
+            </HStack>
+        </Box>
+    );
 };

--- a/refine-nextjs/plugins/i18n-antd/src/components/header/index.tsx
+++ b/refine-nextjs/plugins/i18n-antd/src/components/header/index.tsx
@@ -1,92 +1,101 @@
 import { useContext } from "react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useGetIdentity, useGetLocale } from "@refinedev/core";
 import {
-  useGetLocale,
-  useSetLocale,
-  useGetIdentity,
-} from "@refinedev/core";
-import {
-  Layout as AntdLayout,
-  Space,
-  Menu,
-  Button,
-  Dropdown,
-  Avatar,
-  Typography,
-  Switch,
+    Layout as AntdLayout,
+    Space,
+    Avatar,
+    Typography,
+    Switch,
+    Menu,
+    Button,
+    Dropdown,
+    theme,
 } from "antd";
 import { DownOutlined } from "@ant-design/icons";
-import { useRouter } from "next/router";
-import Link from "next/link";
-
-import { ColorModeContext } from "@contexts";
+import { ColorModeContext } from "../../contexts";
 
 const { Text } = Typography;
+const { useToken } = theme;
 
- interface IUser {
+type IUser = {
+    id: number;
     name: string;
     avatar: string;
-  }
-
-export const Header: React.FC = () => {
-  const locale = useGetLocale();
-  const { locales } = useRouter();
-  const currentLocale = locale();
-  const { data: user } = useGetIdentity<IUser>();
-  const { mode, setMode } = useContext(ColorModeContext);
-
-  const menu = (
-    <Menu selectedKeys={currentLocale ? [currentLocale] : []}>
-      {[...(locales || [])].sort().map((lang: string) => (
-        <Menu.Item
-          key={lang}
-          icon={
-            <span style={{ marginRight: 8 }}>
-              <Avatar size={16} src={`/images/flags/${lang}.svg`} />
-            </span>
-          }
-        >
-          <Link href="/" locale={lang}>
-            {lang === "en" ? "English" : "German"}
-          </Link>
-        </Menu.Item>
-      ))}
-    </Menu>
-  );
-
-  return (
-    <AntdLayout.Header
-      style={{
-        display: "flex",
-        justifyContent: "flex-end",
-        alignItems: "center",
-        padding: "0px 24px",
-        height: "64px",
-      }}
-    >
-      <Switch
-        checkedChildren="🌛"
-        unCheckedChildren="🔆"
-        onChange={() => setMode(mode === "light" ? "dark" : "light")}
-        defaultChecked={mode === "dark"}
-      />
-      <Dropdown overlay={menu}>
-        <Button type="link">
-          <Space>
-            <Avatar size={16} src={`/images/flags/${currentLocale}.svg`} />
-            {currentLocale === "en" ? "English" : "German"}
-            <DownOutlined />
-          </Space>
-        </Button>
-      </Dropdown>
-      <Space style={{ marginLeft: "8px" }}>
-        {user?.name && (
-          <Text style={{ color: "white" }} strong>
-            {user.name}
-          </Text>
-        )}
-        {user?.avatar && <Avatar src={user?.avatar} alt={user?.name} />}
-      </Space>
-    </AntdLayout.Header>
-  );
 };
 
+export const Header: React.FC = () => {
+    const { data: user } = useGetIdentity<IUser>();
+
+    const { token } = useToken();
+    const { mode, setMode } = useContext(ColorModeContext);
+
+    const locale = useGetLocale();
+    const { locales } = useRouter();
+    const currentLocale = locale();
+
+    const menu = (
+        <Menu selectedKeys={currentLocale ? [currentLocale] : []}>
+            {[...(locales || [])].sort().map((lang: string) => (
+                <Menu.Item
+                    key={lang}
+                    icon={
+                        <span style={{ marginRight: 8 }}>
+                            <Avatar
+                                size={16}
+                                src={`/images/flags/${lang}.svg`}
+                            />
+                        </span>
+                    }
+                >
+                    <Link href="/" locale={lang}>
+                        {lang === "en" ? "English" : "German"}
+                    </Link>
+                </Menu.Item>
+            ))}
+        </Menu>
+    );
+
+    return (
+        <AntdLayout.Header
+            style={{
+                backgroundColor: token.colorBgElevated,
+                display: "flex",
+                justifyContent: "flex-end",
+                alignItems: "center",
+                padding: "0px 24px",
+                height: "64px",
+            }}
+        >
+            <Space>
+                <Dropdown overlay={menu}>
+                    <Button type="link">
+                        <Space>
+                            <Avatar
+                                size={16}
+                                src={`/images/flags/${currentLocale}.svg`}
+                            />
+                            {currentLocale === "en" ? "English" : "German"}
+                            <DownOutlined />
+                        </Space>
+                    </Button>
+                </Dropdown>
+                <Switch
+                    checkedChildren="🌛"
+                    unCheckedChildren="🔆"
+                    onChange={() =>
+                        setMode(mode === "light" ? "dark" : "light")
+                    }
+                    defaultChecked={mode === "dark"}
+                />
+                <Space style={{ marginLeft: "8px" }} size="middle">
+                    {user?.name && <Text strong>{user.name}</Text>}
+                    {user?.avatar && (
+                        <Avatar src={user?.avatar} alt={user?.name} />
+                    )}
+                </Space>
+            </Space>
+        </AntdLayout.Header>
+    );
+};

--- a/refine-nextjs/plugins/i18n-chakra/src/components/header/index.tsx
+++ b/refine-nextjs/plugins/i18n-chakra/src/components/header/index.tsx
@@ -1,97 +1,154 @@
-  import { useRouter } from "next/router";
-  import { 
-    useGetIdentity,
-    useGetLocale,
-  } from "@refinedev/core";
-  import NextRouter from "@refinedev/nextjs-router";
-  import { 
-    Box,
-    IconButton,
-    HStack,
-    Text,
+import { useGetIdentity, useGetLocale } from "@refinedev/core";
+import { RefineThemedLayoutHeaderProps } from "@refinedev/chakra-ui";
+import { useRouter } from "next/router";
+import Link from "next/link";
+import {
     Avatar,
+    Box,
+    HStack,
     Icon,
+    IconButton,
+    Text,
+    useColorMode,
+    useColorModeValue,
     Menu,
     MenuButton,
     MenuItem,
     MenuList,
-    useColorMode,
-  } from "@chakra-ui/react";
-  import { IconMoon, IconSun, IconLanguage } from "@tabler/icons";
+} from "@chakra-ui/react";
+import {
+    IconLayoutSidebarLeftCollapse,
+    IconLayoutSidebarLeftExpand,
+    IconMoon,
+    IconSun,
+    IconLanguage,
+} from "@tabler/icons";
 
-  interface IUser {
+type IUser = {
+    id: number;
     name: string;
     avatar: string;
-  }
+};
 
-  export const Header: React.FC = () => {
+export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
+    isSiderOpen,
+    onToggleSiderClick,
+    toggleSiderIcon: toggleSiderIconFromProps,
+}) => {
     const { data: user } = useGetIdentity<IUser>();
-    const showUserInfo = user && (user.name || user.avatar);
-  
+
     const { colorMode, toggleColorMode } = useColorMode();
+
+    const bgColor = useColorModeValue(
+        "refine.header.bg.light",
+        "refine.header.bg.dark",
+    );
 
     const locale = useGetLocale();
     const currentLocale = locale();
-
     const { locales } = useRouter();
-  
+
+    const hasSidebarToggle = Boolean(onToggleSiderClick);
+
     return (
-      <Box
-          py="2"
-          px="4"
-          display="flex"
-          justifyContent="flex-end"
-          gap={2}
-          w="full"
-          bg="chakra-body-bg"
-      >
-          <Menu>
-              <MenuButton
-                  as={IconButton}
-                  aria-label="Options"
-                  icon={<IconLanguage />}
-                  variant="ghost"
-              />
-              <MenuList>
-                  {[...(locales ?? [])].sort().map((lang: string) => (
-                    <MenuItem
-                      key={lang}
-                      as={NextRouter.Link}
-                      href="/" 
-                      locale={lang}
-                      color={lang === currentLocale ? "green" : undefined}
-                      icon={
-                        <Avatar
-                          src={`/images/flags/${lang}.svg`}
-                          h={18}
-                          w={18}
-                        />
-                      }
-                    >
-                      {lang === "en" ? "English" : "German"}
-                    </MenuItem>
-                  ))}
-              </MenuList>
-          </Menu>
-          <IconButton
-              variant="ghost"
-              aria-label="Toggle theme"
-              onClick={toggleColorMode}
-          >
-              <Icon
-                  as={colorMode === "light" ? IconMoon : IconSun}
-                  w="24px"
-                  h="24px"
-              />
-          </IconButton>
-          {showUserInfo && (
+        <Box
+            py="2"
+            pr="4"
+            pl="2"
+            display="flex"
+            alignItems="center"
+            justifyContent={
+                hasSidebarToggle
+                    ? { base: "flex-end", md: "space-between" }
+                    : "flex-end"
+            }
+            w="full"
+            height="64px"
+            bg={bgColor}
+            borderBottom="1px"
+            borderBottomColor={useColorModeValue("gray.200", "gray.700")}
+        >
+            {hasSidebarToggle && (
+                <IconButton
+                    display={{ base: "none", md: "flex" }}
+                    backgroundColor="transparent"
+                    aria-label="sidebar-toggle"
+                    onClick={() => onToggleSiderClick?.()}
+                >
+                    {toggleSiderIconFromProps?.(Boolean(isSiderOpen)) ??
+                        (isSiderOpen ? (
+                            <Icon
+                                as={IconLayoutSidebarLeftCollapse}
+                                boxSize={"24px"}
+                            />
+                        ) : (
+                            <Icon
+                                as={IconLayoutSidebarLeftExpand}
+                                boxSize={"24px"}
+                            />
+                        ))}
+                </IconButton>
+            )}
+
             <HStack>
-                <Text size="sm" fontWeight="bold">
-                    {user?.name}
-                </Text>
-                <Avatar size="sm" name={user?.name} src={user?.avatar} />
+                <Menu>
+                    <MenuButton
+                        as={IconButton}
+                        aria-label="Options"
+                        icon={<IconLanguage />}
+                        variant="ghost"
+                    />
+                    <MenuList>
+                        {[...(locales ?? [])].sort().map((lang: string) => (
+                            <MenuItem
+                                key={lang}
+                                as={Link}
+                                href="/"
+                                locale={lang}
+                                color={
+                                    lang === currentLocale ? "green" : undefined
+                                }
+                                icon={
+                                    <Avatar
+                                        src={`/images/flags/${lang}.svg`}
+                                        h={18}
+                                        w={18}
+                                    />
+                                }
+                            >
+                                {lang === "en" ? "English" : "German"}
+                            </MenuItem>
+                        ))}
+                    </MenuList>
+                </Menu>
+
+                <IconButton
+                    variant="ghost"
+                    aria-label="Toggle theme"
+                    onClick={toggleColorMode}
+                >
+                    <Icon
+                        as={colorMode === "light" ? IconMoon : IconSun}
+                        w="24px"
+                        h="24px"
+                    />
+                </IconButton>
+
+                {(user?.avatar || user?.name) && (
+                    <HStack>
+                        {user?.name && (
+                            <Text size="sm" fontWeight="bold">
+                                {user.name}
+                            </Text>
+                        )}
+                        <Avatar
+                            size="sm"
+                            name={user?.name}
+                            src={user?.avatar}
+                        />
+                    </HStack>
+                )}
             </HStack>
-          )}
-      </Box>
-  );
-  };      
+        </Box>
+    );
+};

--- a/refine-nextjs/plugins/i18n-mantine/src/components/header/index.tsx
+++ b/refine-nextjs/plugins/i18n-mantine/src/components/header/index.tsx
@@ -1,84 +1,105 @@
-    import { useRouter } from "next/router";
-    import NextRouter from "@refinedev/nextjs-router";
-    import {
-        useGetIdentity,
-        useGetLocale,
-        useSetLocale,
-      } from "@refinedev/core";
-      import {
-        ActionIcon,
-        Group,
-        Header as MantineHeader,
-        Title,
-        Avatar,
-        Menu,
-        useMantineColorScheme
-      } from "@mantine/core";
-      import { IconSun, IconMoonStars, IconLanguage } from "@tabler/icons";
-      
-       interface IUser {
+import { useGetIdentity, useGetLocale } from "@refinedev/core";
+import { useRouter } from "next/router";
+import Link from "next/link";
+import {
+    ActionIcon,
+    Group,
+    Header as MantineHeader,
+    Title,
+    Avatar,
+    Menu,
+    useMantineColorScheme,
+    useMantineTheme,
+} from "@mantine/core";
+import { IconLanguage, IconMoonStars, IconSun } from "@tabler/icons";
+
+interface IUser {
     name: string;
     avatar: string;
-  }
-    
-      export const Header: React.FC = () => {
-        const { data: user } = useGetIdentity<IUser>();
-        const showUserInfo = user && (user.name || user.avatar);
-      
-        const { colorScheme, toggleColorScheme } = useMantineColorScheme();
-        const dark = colorScheme === "dark";
-      
-        const locale = useGetLocale();
-        const currentLocale = locale();
-        
-        const { locales } = useRouter();
-      
-        return (
-          <MantineHeader height={50} p="xs">
-            <Group position="right">
-              <Menu shadow="md">
-                <Menu.Target>
-                  <ActionIcon variant="outline">
-                    <IconLanguage size={18} />
-                  </ActionIcon>
-                </Menu.Target>
-      
-                <Menu.Dropdown>
-                  {[...(locales ?? [])].sort().map((lang: string) => (
-                    <Menu.Item
-                      key={lang}
-                      component={NextRouter.Link}
-                      href="/" 
-                      locale={lang}
-                      color={lang === currentLocale ? "primary" : undefined}
-                      icon={
+}
+
+export const Header: React.FC = () => {
+    const { data: user } = useGetIdentity<IUser>();
+
+    const { colorScheme, toggleColorScheme } = useMantineColorScheme();
+    const theme = useMantineTheme();
+    const dark = colorScheme === "dark";
+    const borderColor = dark ? theme.colors.dark[6] : theme.colors.gray[2];
+
+    const locale = useGetLocale();
+    const currentLocale = locale();
+    const { locales } = useRouter();
+
+    return (
+        <MantineHeader
+            zIndex={199}
+            height={64}
+            py={6}
+            px="sm"
+            sx={{
+                borderBottom: `1px solid ${borderColor}`,
+            }}
+        >
+            <Group
+                position="right"
+                align="center"
+                sx={{
+                    height: "100%",
+                }}
+            >
+                <Menu shadow="md">
+                    <Menu.Target>
+                        <ActionIcon variant="outline">
+                            <IconLanguage size={18} />
+                        </ActionIcon>
+                    </Menu.Target>
+
+                    <Menu.Dropdown>
+                        {[...(locales ?? [])].sort().map((lang: string) => (
+                            <Menu.Item
+                                key={lang}
+                                component={Link}
+                                href="/"
+                                locale={lang}
+                                color={
+                                    lang === currentLocale
+                                        ? "primary"
+                                        : undefined
+                                }
+                                icon={
+                                    <Avatar
+                                        src={`/images/flags/${lang}.svg`}
+                                        size={18}
+                                        radius="lg"
+                                    />
+                                }
+                            >
+                                {lang === "en" ? "English" : "German"}
+                            </Menu.Item>
+                        ))}
+                    </Menu.Dropdown>
+                </Menu>
+
+                <ActionIcon
+                    variant="outline"
+                    color={dark ? "yellow" : "primary"}
+                    onClick={() => toggleColorScheme()}
+                    title="Toggle color scheme"
+                >
+                    {dark ? <IconSun size={18} /> : <IconMoonStars size={18} />}
+                </ActionIcon>
+
+                {(user?.name || user?.avatar) && (
+                    <Group spacing="xs">
+                        {user?.name && <Title order={6}>{user?.name}</Title>}
                         <Avatar
-                          src={`/images/flags/${lang}.svg`}
-                          size={18}
-                          radius="lg"
+                            src={user?.avatar}
+                            alt={user?.name}
+                            radius="xl"
                         />
-                      }
-                    >
-                      {lang === "en" ? "English" : "German"}
-                    </Menu.Item>
-                  ))}
-                </Menu.Dropdown>
-              </Menu>
-              <ActionIcon
-                variant="outline"
-                color={dark ? "yellow" : "primary"}
-                onClick={() => toggleColorScheme()}
-                title="Toggle color scheme"
-              >
-                {dark ? <IconSun size={18} /> : <IconMoonStars size={18} />}
-              </ActionIcon>
-              {showUserInfo && (
-                <Group spacing="xs">
-                  <Title order={6}>{user?.name}</Title>
-                  <Avatar src={user?.avatar} alt={user?.name} radius="xl" />
-                </Group>
-              )}
+                    </Group>
+                )}
             </Group>
-          </MantineHeader>
-        );
-      };      
+        </MantineHeader>
+    );
+};

--- a/refine-nextjs/plugins/i18n-mui/src/components/header/index.tsx
+++ b/refine-nextjs/plugins/i18n-mui/src/components/header/index.tsx
@@ -1,98 +1,139 @@
 import React, { useContext } from "react";
-import {
-  useGetIdentity
-} from "@refinedev/core";
-import {
-  AppBar,
-  IconButton,
-  Avatar,
-  Stack,
-  FormControl,
-  MenuItem,
-  Select,
-  Toolbar,
-  Typography,
-} from "@mui/material";
-import { DarkModeOutlined, LightModeOutlined } from "@mui/icons-material";
 import { useRouter } from "next/router";
 import Link from "next/link";
+import { useGetIdentity } from "@refinedev/core";
+import { RefineThemedLayoutHeaderProps } from "@refinedev/mui";
+import {
+    AppBar,
+    IconButton,
+    Avatar,
+    Stack,
+    FormControl,
+    MenuItem,
+    Select,
+    Toolbar,
+    Typography,
+} from "@mui/material";
+import { DarkModeOutlined, LightModeOutlined, Menu } from "@mui/icons-material";
 
 import { ColorModeContext } from "@contexts";
 
- interface IUser {
+interface IUser {
     name: string;
     avatar: string;
-  }
+}
 
-export const Header: React.FC = () => {
-  const { mode, setMode } = useContext(ColorModeContext);
-  const { locale: currentLocale, locales, pathname, query } = useRouter();
+export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
+    isSiderOpen,
+    onToggleSiderClick,
+    toggleSiderIcon: toggleSiderIconFromProps,
+}) => {
+    const { mode, setMode } = useContext(ColorModeContext);
+    const { locale: currentLocale, locales, pathname, query } = useRouter();
 
-  const { data: user } = useGetIdentity<IUser>();
-  const showUserInfo = user && (user.name || user.avatar);
+    const { data: user } = useGetIdentity<IUser>();
 
-  return (
-    <AppBar color="default" position="sticky" elevation={1}>
-      <Toolbar>
-        <Stack
-          direction="row"
-          width="100%"
-          justifyContent="flex-end"
-          alignItems="center"
-        >
-          <IconButton
-            onClick={() => {
-              setMode();
-            }}
-          >
-            {mode === "dark" ? <LightModeOutlined /> : <DarkModeOutlined />}
-          </IconButton>
-          <FormControl sx={{ m: 1, minWidth: 120 }}>
-            <Select
-              disableUnderline
-              defaultValue={currentLocale}
-              inputProps={{ "aria-label": "Without label" }}
-              variant="standard"
-            >
-              {[...(locales ?? [])].sort().map((lang: string) => (
-                <MenuItem
-                  component={Link}
-                  href={{ pathname, query }}
-                  locale={lang}
-                  selected={currentLocale === lang}
-                  key={lang}
-                  defaultValue={lang}
-                  value={lang}
-                >
-                  <Stack
-                    direction="row"
-                    alignItems="center"
-                    justifyContent="center"
-                  >
-                    <Avatar
-                      sx={{
-                        width: "16px",
-                        height: "16px",
-                        marginRight: "5px",
-                      }}
-                      src={`/images/flags/${lang}.svg`}
-                    />
-                    {lang === "en" ? "English" : "German"}
-                  </Stack>
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          {showUserInfo && (
-            <Stack direction="row" gap="16px" alignItems="center">
-              {user.avatar && <Avatar src={user?.avatar} alt={user?.name} />}
-              {user.name && (
-                <Typography variant="subtitle2">{user?.name}</Typography>
-              )}
-            </Stack>
-          )}
-        </Stack>
-      </Toolbar>
-    </AppBar>
-  );
+    const hasSidebarToggle = Boolean(onToggleSiderClick);
+
+    return (
+        <AppBar color="default" position="sticky">
+            <Toolbar>
+                <Stack direction="row" width="100%" alignItems="center">
+                    {hasSidebarToggle && (
+                        <IconButton
+                            aria-label="open drawer"
+                            onClick={() => onToggleSiderClick?.()}
+                            edge="start"
+                            sx={{
+                                mr: 2,
+                                display: { xs: "none", md: "flex" },
+                                ...(isSiderOpen && { display: "none" }),
+                            }}
+                        >
+                            {toggleSiderIconFromProps?.(
+                                Boolean(isSiderOpen),
+                            ) ?? <Menu />}
+                        </IconButton>
+                    )}
+
+                    <Stack
+                        direction="row"
+                        width="100%"
+                        justifyContent="flex-end"
+                        alignItems="center"
+                        gap="16px"
+                    >
+                        <FormControl sx={{ minWidth: 120 }}>
+                            <Select
+                                disableUnderline
+                                defaultValue={currentLocale}
+                                inputProps={{ "aria-label": "Without label" }}
+                                variant="standard"
+                            >
+                                {[...(locales ?? [])]
+                                    .sort()
+                                    .map((lang: string) => (
+                                        <MenuItem
+                                            component={Link}
+                                            href={{ pathname, query }}
+                                            locale={lang}
+                                            selected={currentLocale === lang}
+                                            key={lang}
+                                            defaultValue={lang}
+                                            value={lang}
+                                        >
+                                            <Stack
+                                                direction="row"
+                                                alignItems="center"
+                                                justifyContent="center"
+                                            >
+                                                <Avatar
+                                                    sx={{
+                                                        width: "16px",
+                                                        height: "16px",
+                                                        marginRight: "5px",
+                                                    }}
+                                                    src={`/images/flags/${lang}.svg`}
+                                                />
+                                                {lang === "en"
+                                                    ? "English"
+                                                    : "German"}
+                                            </Stack>
+                                        </MenuItem>
+                                    ))}
+                            </Select>
+                        </FormControl>
+
+                        <IconButton
+                            onClick={() => {
+                                setMode();
+                            }}
+                        >
+                            {mode === "dark" ? (
+                                <LightModeOutlined />
+                            ) : (
+                                <DarkModeOutlined />
+                            )}
+                        </IconButton>
+
+                        {(user?.avatar || user?.name) && (
+                            <Stack
+                                direction="row"
+                                gap="16px"
+                                alignItems="center"
+                                justifyContent="center"
+                            >
+                                {user?.name && (
+                                    <Typography variant="subtitle2">
+                                        {user?.name}
+                                    </Typography>
+                                )}
+                                <Avatar src={user?.avatar} alt={user?.name} />
+                            </Stack>
+                        )}
+                    </Stack>
+                </Stack>
+            </Toolbar>
+        </AppBar>
+    );
 };

--- a/refine-nextjs/plugins/mantine/extend.js
+++ b/refine-nextjs/plugins/mantine/extend.js
@@ -2,37 +2,46 @@ const base = {
     _app: {
         refineProps: ["notificationProvider={notificationProvider}"],
         import: [
-            `import { MantineProvider, Global, ColorScheme } from "@mantine/core";`,
+            `import { MantineProvider, Global, ColorScheme, ColorSchemeProvider} from "@mantine/core";`,
             `import { NotificationsProvider } from "@mantine/notifications";`,
             `import { useLocalStorage } from "@mantine/hooks";`,
-            `import { ColorSchemeProvider } from "@mantine/styles";`
         ],
         refineMantineImports: [
             "notificationProvider",
-            "Layout",
-            "DarkTheme",
-            "LightTheme",
+            "ThemedLayout",
+            "RefineThemes",
         ],
         wrapper: [
-            ["<ColorSchemeProvider colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}>", "</ColorSchemeProvider>"],
-            [`<MantineProvider theme={colorScheme === "dark" ? DarkTheme : LightTheme} withNormalizeCSS withGlobalStyles>`, "</MantineProvider>"],
+            [
+                "<ColorSchemeProvider colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}>",
+                "</ColorSchemeProvider>",
+            ],
+            [
+                "{/* You can change the theme colors here. example: theme={{ ...RefineThemes.Magenta, colorScheme:colorScheme }} */}",
+                "",
+            ],
+            [
+                `<MantineProvider theme={{ ...RefineThemes.Blue, colorScheme:colorScheme }} withNormalizeCSS withGlobalStyles>`,
+                "</MantineProvider>",
+            ],
             [`<Global styles={{ body: { WebkitFontSmoothing: "auto" } }} />`],
-            [`<NotificationsProvider position="top-right">`, "</NotificationsProvider>"],
+            [
+                `<NotificationsProvider position="top-right">`,
+                "</NotificationsProvider>",
+            ],
         ],
         innerHooks: [
             `const [colorScheme, setColorScheme] = useLocalStorage<ColorScheme>({
                 key: "mantine-color-scheme",
                 defaultValue: "light",
                 getInitialValueInEffect: true,
-            });`
+            });`,
         ],
         inner: [
             `const toggleColorScheme = (value?: ColorScheme) =>
-                setColorScheme(value || (colorScheme === "dark" ? "light" : "dark"));`
+                setColorScheme(value || (colorScheme === "dark" ? "light" : "dark"));`,
         ],
-        localImport: [
-            `import { Header } from "@components/header"`,
-        ],
+        localImport: [`import { Header } from "@components/header"`],
     },
 };
 

--- a/refine-nextjs/plugins/mantine/src/components/header/index.tsx
+++ b/refine-nextjs/plugins/mantine/src/components/header/index.tsx
@@ -1,44 +1,67 @@
 import { useGetIdentity } from "@refinedev/core";
 import {
-  ActionIcon,
-  Group,
-  Header as MantineHeader,
-  Title,
-  Avatar,
-  useMantineColorScheme
+    ActionIcon,
+    Group,
+    Header as MantineHeader,
+    Title,
+    Avatar,
+    useMantineColorScheme,
+    useMantineTheme,
 } from "@mantine/core";
 import { IconSun, IconMoonStars } from "@tabler/icons";
 
- interface IUser {
+type IUser = {
+    id: number;
     name: string;
     avatar: string;
-  }
+};
 
 export const Header: React.FC = () => {
-  const { data: user } = useGetIdentity<IUser>();
-  const showUserInfo = user && (user.name || user.avatar);
+    const { data: user } = useGetIdentity<IUser>();
 
-  const { colorScheme, toggleColorScheme } = useMantineColorScheme();
-  const dark = colorScheme === "dark";
+    const theme = useMantineTheme();
 
-  return (
-      <MantineHeader height={50} p="xs">
-          <Group position="right">
-              <ActionIcon
-                  variant="outline"
-                  color={dark ? "yellow" : "primary"}
-                  onClick={() => toggleColorScheme()}
-                  title="Toggle color scheme"
-              >
-                  {dark ? <IconSun size={18} /> : <IconMoonStars size={18} />}
-              </ActionIcon>
-              {showUserInfo && (
-                <Group spacing="xs">
-                    <Title order={6}>{user?.name}</Title>
-                    <Avatar src={user?.avatar} alt={user?.name} radius="xl" />
-                </Group>
-              )}
-          </Group>
-      </MantineHeader>
-  );
+    const { colorScheme, toggleColorScheme } = useMantineColorScheme();
+    const dark = colorScheme === "dark";
+
+    const borderColor = dark ? theme.colors.dark[6] : theme.colors.gray[2];
+
+    return (
+        <MantineHeader
+            zIndex={199}
+            height={64}
+            py={6}
+            px="sm"
+            sx={{
+                borderBottom: `1px solid ${borderColor}`,
+            }}
+        >
+            <Group
+                position="right"
+                align="center"
+                sx={{
+                    height: "100%",
+                }}
+            >
+                <ActionIcon
+                    variant="outline"
+                    color={dark ? "yellow" : "primary"}
+                    onClick={() => toggleColorScheme()}
+                    title="Toggle color scheme"
+                >
+                    {dark ? <IconSun size={18} /> : <IconMoonStars size={18} />}
+                </ActionIcon>
+                {(user?.name || user?.avatar) && (
+                    <Group spacing="xs">
+                        {user?.name && <Title order={6}>{user?.name}</Title>}
+                        <Avatar
+                            src={user?.avatar}
+                            alt={user?.name}
+                            radius="xl"
+                        />
+                    </Group>
+                )}
+            </Group>
+        </MantineHeader>
+    );
 };

--- a/refine-nextjs/plugins/mui/extend.js
+++ b/refine-nextjs/plugins/mui/extend.js
@@ -4,17 +4,17 @@ const base = {
         refineMuiImports: [
             "notificationProvider",
             "RefineSnackbarProvider",
-            "Layout"
+            "ThemedLayout",
         ],
         wrapper: [
             ["<ColorModeContextProvider>", "</ColorModeContextProvider>"],
             ["<CssBaseline />"],
-            [`<GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />`],
+            [
+                `<GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />`,
+            ],
             ["<RefineSnackbarProvider>", "</RefineSnackbarProvider>"],
         ],
-        import: [
-            `import { CssBaseline, GlobalStyles } from "@mui/material";`,
-        ],
+        import: [`import { CssBaseline, GlobalStyles } from "@mui/material";`],
         localImport: [
             'import { ColorModeContextProvider } from "@contexts";',
             'import { Header } from "@components/header";',

--- a/refine-nextjs/plugins/mui/src/components/header/index.tsx
+++ b/refine-nextjs/plugins/mui/src/components/header/index.tsx
@@ -1,54 +1,97 @@
 import React, { useContext } from "react";
 import { useGetIdentity } from "@refinedev/core";
 import {
-  AppBar,
-  IconButton,
-  Avatar,
-  Stack,
-  Toolbar,
-  Typography,
+    AppBar,
+    IconButton,
+    Avatar,
+    Stack,
+    Toolbar,
+    Typography,
 } from "@mui/material";
-import { DarkModeOutlined, LightModeOutlined } from "@mui/icons-material";
+import { RefineThemedLayoutHeaderProps } from "@refinedev/mui";
+import { DarkModeOutlined, LightModeOutlined, Menu } from "@mui/icons-material";
 
 import { ColorModeContext } from "@contexts";
 
-interface IUser {
+type IUser = {
+    id: number;
     name: string;
     avatar: string;
-}
+};
 
-export const Header: React.FC = () => {
-  const { mode, setMode } = useContext(ColorModeContext);
+export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
+    isSiderOpen,
+    onToggleSiderClick,
+    toggleSiderIcon: toggleSiderIconFromProps,
+}) => {
+    const { mode, setMode } = useContext(ColorModeContext);
 
-  const { data: user } = useGetIdentity<IUser>();
-  const showUserInfo = user && (user.name || user.avatar);
+    const { data: user } = useGetIdentity<IUser>();
 
-  return (
-    <AppBar color="default" position="sticky" elevation={1}>
-      <Toolbar>
-        <Stack
-            direction="row"
-            width="100%"
-            justifyContent="flex-end"
-            alignItems="center"
-        >
-          <IconButton
-            onClick={() => {
-              setMode();
-            }}
-          >
-            {mode === "dark" ? <LightModeOutlined /> : <DarkModeOutlined />}
-          </IconButton>
-          {showUserInfo && (
-            <Stack direction="row" gap="16px" alignItems="center">
-              {user.avatar && <Avatar src={user?.avatar} alt={user?.name} />}
-              {user.name && (
-                <Typography variant="subtitle2">{user?.name}</Typography>
-              )}
-            </Stack>
-          )}
-        </Stack>
-      </Toolbar>
-    </AppBar>
-  );
+    const hasSidebarToggle = Boolean(onToggleSiderClick);
+
+    return (
+        <AppBar color="default" position="sticky">
+            <Toolbar>
+                <Stack
+                    direction="row"
+                    width="100%"
+                    justifyContent="flex-end"
+                    alignItems="center"
+                >
+                    {hasSidebarToggle && (
+                        <IconButton
+                            aria-label="open drawer"
+                            onClick={() => onToggleSiderClick?.()}
+                            edge="start"
+                            sx={{
+                                mr: 2,
+                                display: { xs: "none", md: "flex" },
+                                ...(isSiderOpen && { display: "none" }),
+                            }}
+                        >
+                            {toggleSiderIconFromProps?.(
+                                Boolean(isSiderOpen),
+                            ) ?? <Menu />}
+                        </IconButton>
+                    )}
+
+                    <Stack
+                        direction="row"
+                        width="100%"
+                        justifyContent="flex-end"
+                        alignItems="center"
+                    >
+                        <IconButton
+                            onClick={() => {
+                                setMode();
+                            }}
+                        >
+                            {mode === "dark" ? (
+                                <LightModeOutlined />
+                            ) : (
+                                <DarkModeOutlined />
+                            )}
+                        </IconButton>
+
+                        {(user?.avatar || user?.name) && (
+                            <Stack
+                                direction="row"
+                                gap="16px"
+                                alignItems="center"
+                                justifyContent="center"
+                            >
+                                {user?.name && (
+                                    <Typography variant="subtitle2">
+                                        {user?.name}
+                                    </Typography>
+                                )}
+                                <Avatar src={user?.avatar} alt={user?.name} />
+                            </Stack>
+                        )}
+                    </Stack>
+                </Stack>
+            </Toolbar>
+        </AppBar>
+    );
 };

--- a/refine-nextjs/plugins/mui/src/contexts/index.tsx
+++ b/refine-nextjs/plugins/mui/src/contexts/index.tsx
@@ -6,7 +6,7 @@ import React, {
 } from "react";
 import { useMediaQuery } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
-import { DarkTheme, LightTheme } from "@refinedev/mui";
+import { RefineThemes } from "@refinedev/mui";
 import { parseCookies, setCookie } from "nookies";
 
 type ColorModeContextType = {
@@ -52,7 +52,12 @@ export const ColorModeContextProvider: React.FC<PropsWithChildren> = ({
                 mode,
             }}
         >
-            <ThemeProvider theme={mode === "light" ? LightTheme : DarkTheme}>
+            <ThemeProvider
+                // you can change the theme colors here. example: mode === "light" ? RefineThemes.Magenta : RefineThemes.MagentaDark
+                theme={
+                    mode === "light" ? RefineThemes.Blue : RefineThemes.BlueDark
+                }
+            >
                 {children}
             </ThemeProvider>
         </ColorModeContext.Provider>

--- a/refine-nextjs/template/pages/_app.tsx
+++ b/refine-nextjs/template/pages/_app.tsx
@@ -45,9 +45,9 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout): JSX.Element {
         }
 
         return (
-            <Layout Header={Header}>
+            <ThemedLayout Header={Header}>
                 <Component {...pageProps} />
-            </Layout>
+            </ThemedLayout>
         );
     };
 


### PR DESCRIPTION
refine-nextjs:

-   [x] antd, i18n-antd:

    -   [x] `<Layout>` updated to `<ThemedLayout>`.
    -   [x] `<Header>` copied from `<ThemedHeader>`.

-   [x] mui, 18n-mui:

    -   [x] `<Layout>` updated to `<ThemedLayout>`.
    -   [x] `<Header>` copied from `<ThemedHeader>`.

-   [x] chakra-ui, i18n-chakra-ui:

    -   [x] `<Layout>` updated to `<ThemedLayout>`.
    -   [x] `<Header>` copied from `<ThemedHeader>`.

-   [x] mantine, i18n-mantine:
    -   [x] `<Layout>` updated to `<ThemedLayout>`.
    -   [x] `<Header>` copied from `<ThemedHeader>`.


