### PR TITLE
feat(refine-remix): add themed layout to auth provider pages

### DIFF
--- a/refine-remix/plugins/antd/app/components/header/index.tsx
+++ b/refine-remix/plugins/antd/app/components/header/index.tsx
@@ -1,44 +1,58 @@
 import { useContext } from "react";
 import { useGetIdentity } from "@refinedev/core";
 import {
-  Layout as AntdLayout,
-  Space,
-  Avatar,
-  Typography,
-  Switch,
+    Layout as AntdLayout,
+    Space,
+    Avatar,
+    Typography,
+    Switch,
+    theme,
 } from "antd";
 import { ColorModeContext } from "@contexts";
 
 const { Text } = Typography;
+const { useToken } = theme;
+
+type IUser = {
+    id: number;
+    name: string;
+    avatar: string;
+};
 
 export const Header: React.FC = () => {
-  const { data: user } = useGetIdentity();
-  const { mode, setMode } = useContext(ColorModeContext);
+    const { token } = useToken();
+    const { data: user } = useGetIdentity<IUser>();
+    const { mode, setMode } = useContext(ColorModeContext);
 
-  return (
-    <AntdLayout.Header
-      style={{
-        display: "flex",
-        justifyContent: "flex-end",
-        alignItems: "center",
-        padding: "0px 24px",
-        height: "64px",
-      }}
-    >
-      <Switch
-        checkedChildren="🌛"
-        unCheckedChildren="🔆"
-        onChange={() => setMode(mode === "light" ? "dark" : "light")}
-        defaultChecked={mode === "dark"}
-      />
-      <Space style={{ marginLeft: "8px" }}>
-        {user?.name && (
-          <Text style={{ color: "white" }} strong>
-            {user.name}
-          </Text>
-        )}
-        {user?.avatar && <Avatar src={user?.avatar} alt={user?.name} />}
-      </Space>
-    </AntdLayout.Header>
-  );
+    return (
+        <AntdLayout.Header
+            style={{
+                backgroundColor: token.colorBgElevated,
+                display: "flex",
+                justifyContent: "flex-end",
+                alignItems: "center",
+                padding: "0px 24px",
+                height: "64px",
+            }}
+        >
+            <Space>
+                <Switch
+                    checkedChildren="🌛"
+                    unCheckedChildren="🔆"
+                    onChange={() =>
+                        setMode(mode === "light" ? "dark" : "light")
+                    }
+                    defaultChecked={mode === "dark"}
+                />
+                {(user?.name || user?.avatar) && (
+                    <Space style={{ marginLeft: "8px" }} size="middle">
+                        {user?.name && <Text strong>{user.name}</Text>}
+                        {user?.avatar && (
+                            <Avatar src={user?.avatar} alt={user?.name} />
+                        )}
+                    </Space>
+                )}
+            </Space>
+        </AntdLayout.Header>
+    );
 };

--- a/refine-remix/plugins/antd/app/contexts/index.tsx
+++ b/refine-remix/plugins/antd/app/contexts/index.tsx
@@ -1,61 +1,65 @@
 import React, {
-  PropsWithChildren,
-  createContext,
-  useEffect,
-  useState,
+    PropsWithChildren,
+    createContext,
+    useEffect,
+    useState,
 } from "react";
+import { RefineThemes } from "@refinedev/antd";
 import { ConfigProvider, theme } from "antd";
 import { parseCookies, setCookie } from "nookies";
 
 type ColorModeContextType = {
-  mode: string;
-  setMode: (mode: string) => void;
+    mode: string;
+    setMode: (mode: string) => void;
 };
 
 export const ColorModeContext = createContext<ColorModeContextType>(
-  {} as ColorModeContextType
+    {} as ColorModeContextType,
 );
 
 export const ColorModeContextProvider: React.FC<PropsWithChildren> = ({
-  children,
+    children,
 }) => {
-  const [isMounted, setIsMounted] = useState(false);
-  const [mode, setMode] = useState("light");
+    const [isMounted, setIsMounted] = useState(false);
+    const [mode, setMode] = useState("light");
 
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
+    useEffect(() => {
+        setIsMounted(true);
+    }, []);
 
-  useEffect(() => {
-    if (isMounted) {
-      setMode(parseCookies()["theme"]);
-    }
-  }, [isMounted]);
+    useEffect(() => {
+        if (isMounted) {
+            setMode(parseCookies()["theme"]);
+        }
+    }, [isMounted]);
 
-  const setColorMode = () => {
-    if (mode === "light") {
-      setMode("dark");
-    } else {
-      setMode("light");
-    }
-  };
+    const setColorMode = () => {
+        if (mode === "light") {
+            setMode("dark");
+        } else {
+            setMode("light");
+        }
+    };
 
-  const { darkAlgorithm, defaultAlgorithm } = theme;
+    const { darkAlgorithm, defaultAlgorithm } = theme;
 
-  return (
-    <ColorModeContext.Provider
-      value={{
-        setMode: setColorMode,
-        mode,
-      }}
-    >
-      <ConfigProvider
-        theme={{
-          algorithm: mode === "light" ? defaultAlgorithm : darkAlgorithm,
-        }}
-      >
-        {children}
-      </ConfigProvider>
-    </ColorModeContext.Provider>
-  );
+    return (
+        <ColorModeContext.Provider
+            value={{
+                setMode: setColorMode,
+                mode,
+            }}
+        >
+            <ConfigProvider
+                // you can change the theme colors here. example: ...RefineThemes.Magenta,
+                theme={{
+                    ...RefineThemes.Blue,
+                    algorithm:
+                        mode === "light" ? defaultAlgorithm : darkAlgorithm,
+                }}
+            >
+                {children}
+            </ConfigProvider>
+        </ColorModeContext.Provider>
+    );
 };

--- a/refine-remix/plugins/antd/extend.js
+++ b/refine-remix/plugins/antd/extend.js
@@ -1,17 +1,13 @@
 const base = {
     _app: {
         refineProps: ["notificationProvider={notificationProvider}"],
-        import: [
-            'import resetStyle from "@refinedev/antd/dist/reset.css";',
-        ],
+        import: ['import resetStyle from "@refinedev/antd/dist/reset.css";'],
         refineAntdImports: ["notificationProvider"],
         styleImport: ['{ rel: "stylesheet", href: resetStyle }'],
         wrapper: [
-            [`<ColorModeContextProvider>`, `</ColorModeContextProvider>`]
+            [`<ColorModeContextProvider>`, `</ColorModeContextProvider>`],
         ],
-        localImport: [
-            `import { ColorModeContextProvider } from "@contexts";`,
-        ],
+        localImport: [`import { ColorModeContextProvider } from "@contexts";`],
     },
 };
 

--- a/refine-remix/plugins/auth-provider-auth0/app/routes/_layout.tsx
+++ b/refine-remix/plugins/auth-provider-auth0/app/routes/_layout.tsx
@@ -2,16 +2,16 @@ import { Outlet } from "@remix-run/react";
 import type { LoaderArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 <%_ if (answers["ui-framework"] === 'antd') { _%>
-     import { Layout } from "@refinedev/antd";
+     import { ThemedLayout } from "@refinedev/antd";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mui') { _%>
-     import { Layout } from "@refinedev/mui";
+     import { ThemedLayout } from "@refinedev/mui";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mantine') { _%>
-     import { Layout } from "@refinedev/mantine";
+     import { ThemedLayout } from "@refinedev/mantine";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'chakra') { _%>
-     import { Layout } from "@refinedev/chakra-ui";
+     import { ThemedLayout } from "@refinedev/chakra-ui";
  <%_ } _%>
  import { RefineKbar } from "@refinedev/kbar";
 
@@ -25,9 +25,9 @@ export default function BaseLayout() {
                 <Outlet />
                 <RefineKbar />
             <%_ } else { _%>
-                <Layout Header={Header}>
+                <ThemedLayout Header={Header}>
                     <Outlet />
-                </Layout>
+                </ThemedLayout>
                 <RefineKbar />
             <%_ } _%>
         </>

--- a/refine-remix/plugins/auth-provider-custom/app/routes/_layout.tsx
+++ b/refine-remix/plugins/auth-provider-custom/app/routes/_layout.tsx
@@ -2,16 +2,16 @@ import { Outlet } from "@remix-run/react";
 import type { LoaderArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 <%_ if (answers["ui-framework"] === 'antd') { _%>
-     import { Layout } from "@refinedev/antd";
+     import { ThemedLayout } from "@refinedev/antd";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mui') { _%>
-     import { Layout } from "@refinedev/mui";
+     import { ThemedLayout } from "@refinedev/mui";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mantine') { _%>
-     import { Layout } from "@refinedev/mantine";
+     import { ThemedLayout } from "@refinedev/mantine";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'chakra') { _%>
-     import { Layout } from "@refinedev/chakra-ui";
+     import { ThemedLayout } from "@refinedev/chakra-ui";
  <%_ } _%>
  import { RefineKbar } from "@refinedev/kbar";
 
@@ -25,9 +25,9 @@ export default function BaseLayout() {
                 <Outlet />
                 <RefineKbar />
             <%_ } else { _%>
-                <Layout Header={Header}>
+                <ThemedLayout Header={Header}>
                     <Outlet />
-                </Layout>
+                </ThemedLayout>
                 <RefineKbar />
             <%_ } _%>
         </>

--- a/refine-remix/plugins/auth-provider-google/app/routes/_layout.tsx
+++ b/refine-remix/plugins/auth-provider-google/app/routes/_layout.tsx
@@ -2,16 +2,16 @@ import { Outlet } from "@remix-run/react";
 import type { LoaderArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 <%_ if (answers["ui-framework"] === 'antd') { _%>
-     import { Layout } from "@refinedev/antd";
+     import { ThemedLayout } from "@refinedev/antd";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mui') { _%>
-     import { Layout } from "@refinedev/mui";
+     import { ThemedLayout } from "@refinedev/mui";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mantine') { _%>
-     import { Layout } from "@refinedev/mantine";
+     import { ThemedLayout } from "@refinedev/mantine";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'chakra') { _%>
-     import { Layout } from "@refinedev/chakra-ui";
+     import { ThemedLayout } from "@refinedev/chakra-ui";
  <%_ } _%>
  import { RefineKbar } from "@refinedev/kbar";
 
@@ -25,9 +25,9 @@ export default function BaseLayout() {
                 <Outlet />
                 <RefineKbar />
             <%_ } else { _%>
-                <Layout Header={Header}>
+                <ThemedLayout Header={Header}>
                     <Outlet />
-                </Layout>
+                </ThemedLayout>
                 <RefineKbar />
             <%_ } _%>
         </>

--- a/refine-remix/plugins/auth-provider-keycloak/app/routes/_layout.tsx
+++ b/refine-remix/plugins/auth-provider-keycloak/app/routes/_layout.tsx
@@ -2,16 +2,16 @@ import { Outlet } from "@remix-run/react";
 import type { LoaderArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 <%_ if (answers["ui-framework"] === 'antd') { _%>
-     import { Layout } from "@refinedev/antd";
+     import { ThemedLayout } from "@refinedev/antd";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mui') { _%>
-     import { Layout } from "@refinedev/mui";
+     import { ThemedLayout } from "@refinedev/mui";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mantine') { _%>
-     import { Layout } from "@refinedev/mantine";
+     import { ThemedLayout } from "@refinedev/mantine";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'chakra') { _%>
-     import { Layout } from "@refinedev/chakra-ui";
+     import { ThemedLayout } from "@refinedev/chakra-ui";
  <%_ } _%>
  import { RefineKbar } from "@refinedev/kbar";
 
@@ -25,9 +25,9 @@ export default function BaseLayout() {
                 <Outlet />
                 <RefineKbar />
             <%_ } else { _%>
-                <Layout Header={Header}>
+                <ThemedLayout Header={Header}>
                     <Outlet />
-                </Layout>
+                </ThemedLayout>
                 <RefineKbar />
             <%_ } _%>
         </>

--- a/refine-remix/plugins/chakra/app/components/header/index.tsx
+++ b/refine-remix/plugins/chakra/app/components/header/index.tsx
@@ -1,42 +1,112 @@
+import React from "react";
 import { useGetIdentity } from "@refinedev/core";
-import { Box, IconButton, HStack, Text, Avatar, Icon, useColorMode } from "@chakra-ui/react";
-import { IconMoon, IconSun } from "@tabler/icons";
+import {
+    Box,
+    IconButton,
+    HStack,
+    Text,
+    Avatar,
+    Icon,
+    useColorMode,
+    useColorModeValue,
+} from "@chakra-ui/react";
+import { RefineThemedLayoutHeaderProps } from "@refinedev/chakra-ui";
+import {
+    IconMoon,
+    IconSun,
+    IconLayoutSidebarLeftCollapse,
+    IconLayoutSidebarLeftExpand,
+} from "@tabler/icons";
 
-export const Header: React.FC = () => {
-  const { data: user } = useGetIdentity();
-  const showUserInfo = user && (user.name || user.avatar);
+type IUser = {
+    id: number;
+    name: string;
+    avatar: string;
+};
 
-  const { colorMode, toggleColorMode } = useColorMode();
+export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
+    isSiderOpen,
+    onToggleSiderClick,
+    toggleSiderIcon: toggleSiderIconFromProps,
+}) => {
+    const { data: user } = useGetIdentity<IUser>();
 
-  return (
-    <Box
-        py="2"
-        px="4"
-        display="flex"
-        justifyContent="flex-end"
-        gap={2}
-        w="full"
-        bg="chakra-body-bg"
-    >
-        <IconButton
-            variant="ghost"
-            aria-label="Toggle theme"
-            onClick={toggleColorMode}
+    const { colorMode, toggleColorMode } = useColorMode();
+
+    const bgColor = useColorModeValue(
+        "refine.header.bg.light",
+        "refine.header.bg.dark",
+    );
+
+    const hasSidebarToggle = Boolean(onToggleSiderClick);
+
+    return (
+        <Box
+            py="2"
+            pr="4"
+            pl="2"
+            display="flex"
+            alignItems="center"
+            justifyContent={
+                hasSidebarToggle
+                    ? { base: "flex-end", md: "space-between" }
+                    : "flex-end"
+            }
+            w="full"
+            height="64px"
+            bg={bgColor}
+            borderBottom="1px"
+            borderBottomColor={useColorModeValue("gray.200", "gray.700")}
         >
-            <Icon
-                as={colorMode === "light" ? IconMoon : IconSun}
-                w="24px"
-                h="24px"
-            />
-        </IconButton>
-        {showUserInfo && (
-          <HStack>
-              <Text size="sm" fontWeight="bold">
-                  {user?.name}
-              </Text>
-            <Avatar size="sm" name={user?.name} src={user?.avatar} />
-          </HStack>
-        )}
-    </Box>
-);
+            {hasSidebarToggle && (
+                <IconButton
+                    display={{ base: "none", md: "flex" }}
+                    backgroundColor="transparent"
+                    aria-label="sidebar-toggle"
+                    onClick={() => onToggleSiderClick?.()}
+                >
+                    {toggleSiderIconFromProps?.(Boolean(isSiderOpen)) ??
+                        (isSiderOpen ? (
+                            <Icon
+                                as={IconLayoutSidebarLeftCollapse}
+                                boxSize={"24px"}
+                            />
+                        ) : (
+                            <Icon
+                                as={IconLayoutSidebarLeftExpand}
+                                boxSize={"24px"}
+                            />
+                        ))}
+                </IconButton>
+            )}
+
+            <HStack>
+                <IconButton
+                    variant="ghost"
+                    aria-label="Toggle theme"
+                    onClick={toggleColorMode}
+                >
+                    <Icon
+                        as={colorMode === "light" ? IconMoon : IconSun}
+                        w="24px"
+                        h="24px"
+                    />
+                </IconButton>
+                {(user?.avatar || user?.name) && (
+                    <HStack>
+                        {user?.name && (
+                            <Text size="sm" fontWeight="bold">
+                                {user.name}
+                            </Text>
+                        )}
+                        <Avatar
+                            size="sm"
+                            name={user?.name}
+                            src={user?.avatar}
+                        />
+                    </HStack>
+                )}
+            </HStack>
+        </Box>
+    );
 };

--- a/refine-remix/plugins/chakra/app/root.tsx
+++ b/refine-remix/plugins/chakra/app/root.tsx
@@ -13,7 +13,7 @@ import { MetaFunction, LinksFunction } from '@remix-run/node' // Depends on the 
 import { Refine, GitHubBanner, <%- (_app.refineImports || []).join("\n,") _%> } from '@refinedev/core';
 <%_ if (answers["ui-framework"] === 'chakra') { _%>
     import {ChakraProvider} from "@chakra-ui/react";
-    import {  refineTheme, <%- (_app.refineChakraImports || []).join("\n,") _%> } from '@refinedev/chakra-ui';
+    import {  RefineThemes, <%- (_app.refineChakraImports || []).join("\n,") _%> } from '@refinedev/chakra-ui';
 <%_ } _%>
 import { RefineKbar, RefineKbarProvider } from "@refinedev/kbar";
 import routerProvider, { UnsavedChangesNotifier } from "@refinedev/remix-router";
@@ -105,7 +105,8 @@ export default function App() {
   return (
     <Document>
       <GitHubBanner />
-      <ChakraProvider theme={refineTheme}>
+      {/* You can change the theme colors here. example: theme={RefineThemes.Magenta} */}
+      <ChakraProvider theme={RefineThemes.Blue}>
       <RefineKbarProvider>
       <%- top.join("\n") %>
         <Refine

--- a/refine-remix/plugins/data-provider-appwrite/app/routes/_layout.tsx
+++ b/refine-remix/plugins/data-provider-appwrite/app/routes/_layout.tsx
@@ -2,16 +2,16 @@ import { Outlet } from "@remix-run/react";
 import type { LoaderArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 <%_ if (answers["ui-framework"] === 'antd') { _%>
-     import { Layout } from "@refinedev/antd";
+     import { ThemedLayout } from "@refinedev/antd";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mui') { _%>
-     import { Layout } from "@refinedev/mui";
+     import { ThemedLayout } from "@refinedev/mui";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mantine') { _%>
-     import { Layout } from "@refinedev/mantine";
+     import { ThemedLayout } from "@refinedev/mantine";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'chakra') { _%>
-     import { Layout } from "@refinedev/chakra-ui";
+     import { ThemedLayout } from "@refinedev/chakra-ui";
  <%_ } _%>
 
 import { Header } from "@components/header";
@@ -23,9 +23,9 @@ export default function BaseLayout() {
              <%_ if (answers["ui-framework"] === 'no') { _%>
                 <Outlet />
             <%_ } else { _%>
-                <Layout Header={Header}>
+                <ThemedLayout Header={Header}>
                     <Outlet />
-                </Layout>
+                </ThemedLayout>
             <%_ } _%>
         </>
     );

--- a/refine-remix/plugins/data-provider-strapi-v4/app/routes/_layout.tsx
+++ b/refine-remix/plugins/data-provider-strapi-v4/app/routes/_layout.tsx
@@ -2,16 +2,16 @@ import { Outlet } from "@remix-run/react";
 import type { LoaderArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 <%_ if (answers["ui-framework"] === 'antd') { _%>
-     import { Layout } from "@refinedev/antd";
+     import { ThemedLayout } from "@refinedev/antd";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mui') { _%>
-     import { Layout } from "@refinedev/mui";
+     import { ThemedLayout } from "@refinedev/mui";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mantine') { _%>
-     import { Layout } from "@refinedev/mantine";
+     import { ThemedLayout } from "@refinedev/mantine";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'chakra') { _%>
-     import { Layout } from "@refinedev/chakra-ui";
+     import { ThemedLayout } from "@refinedev/chakra-ui";
  <%_ } _%>
 
 import { Header } from "@components/header";
@@ -23,9 +23,9 @@ export default function BaseLayout() {
              <%_ if (answers["ui-framework"] === 'no') { _%>
                 <Outlet />
             <%_ } else { _%>
-                <Layout Header={Header}>
+                <ThemedLayout Header={Header}>
                     <Outlet />
-                </Layout>
+                </ThemedLayout>
             <%_ } _%>
         </>
     );

--- a/refine-remix/plugins/data-provider-supabase/app/routes/_layout.tsx
+++ b/refine-remix/plugins/data-provider-supabase/app/routes/_layout.tsx
@@ -2,16 +2,16 @@ import { Outlet } from "@remix-run/react";
 import type { LoaderArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 <%_ if (answers["ui-framework"] === 'antd') { _%>
-     import { Layout } from "@refinedev/antd";
+     import { ThemedLayout } from "@refinedev/antd";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mui') { _%>
-     import { Layout } from "@refinedev/mui";
+     import { ThemedLayout } from "@refinedev/mui";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'mantine') { _%>
-     import { Layout } from "@refinedev/mantine";
+     import { ThemedLayout } from "@refinedev/mantine";
  <%_ } _%>
  <%_ if (answers["ui-framework"] === 'chakra') { _%>
-     import { Layout } from "@refinedev/chakra-ui";
+     import { ThemedLayout } from "@refinedev/chakra-ui";
  <%_ } _%>
 
 import { Header } from "@components/header";
@@ -23,9 +23,9 @@ export default function BaseLayout() {
              <%_ if (answers["ui-framework"] === 'no') { _%>
                 <Outlet />
             <%_ } else { _%>
-                <Layout Header={Header}>
+                <ThemedLayout Header={Header}>
                     <Outlet />
-                </Layout>
+                </ThemedLayout>
             <%_ } _%>
         </>
     );

--- a/refine-remix/plugins/inferencer/app/routes/_layout.tsx
+++ b/refine-remix/plugins/inferencer/app/routes/_layout.tsx
@@ -1,15 +1,15 @@
 import { Outlet } from "@remix-run/react";
 <%_ if (answers["ui-framework"] === 'antd') { _%>
-    import { Layout } from "@refinedev/antd";
+    import { ThemedLayout } from "@refinedev/antd";
 <%_ } _%>
 <%_ if (answers["ui-framework"] === 'mui') { _%>
-    import { Layout } from "@refinedev/mui";
+    import { ThemedLayout } from "@refinedev/mui";
 <%_ } _%>
 <%_ if (answers["ui-framework"] === 'mantine') { _%>
-    import { Layout } from "@refinedev/mantine";
+    import { ThemedLayout } from "@refinedev/mantine";
 <%_ } _%>
 <%_ if (answers["ui-framework"] === 'chakra') { _%>
-    import { Layout } from "@refinedev/chakra-ui";
+    import { ThemedLayout } from "@refinedev/chakra-ui";
 <%_ } _%>
 
 <%_ if (_app.isAuthProviderCheck) { _%>
@@ -26,9 +26,9 @@ export default function BaseLayout() {
              <%_ if (answers["ui-framework"] === 'no') { _%>
                 <Outlet />
             <%_ } else { _%>
-                <Layout Header={Header}>
+                <ThemedLayout Header={Header}>
                     <Outlet />
-                </Layout>
+                </ThemedLayout>
             <%_ } _%>
         </>
     );

--- a/refine-remix/plugins/mantine/app/components/header/index.tsx
+++ b/refine-remix/plugins/mantine/app/components/header/index.tsx
@@ -1,39 +1,68 @@
+import React from "react";
 import { useGetIdentity } from "@refinedev/core";
 import {
-  ActionIcon,
-  Group,
-  Header as MantineHeader,
-  Title,
-  Avatar,
-  useMantineColorScheme,
+    ActionIcon,
+    Group,
+    Header as MantineHeader,
+    Title,
+    Avatar,
+    useMantineColorScheme,
+    useMantineTheme,
 } from "@mantine/core";
 import { IconSun, IconMoonStars } from "@tabler/icons";
 
+type IUser = {
+    id: number;
+    name: string;
+    avatar: string;
+};
+
 export const Header: React.FC = () => {
-  const { data: user } = useGetIdentity();
-  const showUserInfo = user && (user.name || user.avatar);
+    const { data: user } = useGetIdentity<IUser>();
 
-  const { colorScheme, toggleColorScheme } = useMantineColorScheme();
-  const dark = colorScheme === "dark";
+    const theme = useMantineTheme();
 
-  return (
-      <MantineHeader height={50} p="xs">
-          <Group position="right">
-              <ActionIcon
-                  variant="outline"
-                  color={dark ? "yellow" : "primary"}
-                  onClick={() => toggleColorScheme()}
-                  title="Toggle color scheme"
-              >
-                  {dark ? <IconSun size={18} /> : <IconMoonStars size={18} />}
-              </ActionIcon>
-              {showUserInfo && (
-                <Group spacing="xs">
-                    <Title order={6}>{user?.name}</Title>
-                    <Avatar src={user?.avatar} alt={user?.name} radius="xl" />
-                </Group>
-              )}
-          </Group>
-      </MantineHeader>
-  );
+    const { colorScheme, toggleColorScheme } = useMantineColorScheme();
+    const dark = colorScheme === "dark";
+
+    const borderColor = dark ? theme.colors.dark[6] : theme.colors.gray[2];
+
+    return (
+        <MantineHeader
+            zIndex={199}
+            height={64}
+            py={6}
+            px="sm"
+            sx={{
+                borderBottom: `1px solid ${borderColor}`,
+            }}
+        >
+            <Group
+                position="right"
+                align="center"
+                sx={{
+                    height: "100%",
+                }}
+            >
+                <ActionIcon
+                    variant="outline"
+                    color={dark ? "yellow" : "primary"}
+                    onClick={() => toggleColorScheme()}
+                    title="Toggle color scheme"
+                >
+                    {dark ? <IconSun size={18} /> : <IconMoonStars size={18} />}
+                </ActionIcon>
+                {(user?.name || user?.avatar) && (
+                    <Group spacing="xs">
+                        {user?.name && <Title order={6}>{user?.name}</Title>}
+                        <Avatar
+                            src={user?.avatar}
+                            alt={user?.name}
+                            radius="xl"
+                        />
+                    </Group>
+                )}
+            </Group>
+        </MantineHeader>
+    );
 };

--- a/refine-remix/plugins/mantine/app/root.tsx
+++ b/refine-remix/plugins/mantine/app/root.tsx
@@ -50,8 +50,6 @@ export default function App() {
     <%- (_app.innerHooks || []).join("\n") %>
     <%- (_app.inner || []).join("\n") %>
     return (
-
-    <MantineProvider theme={LightTheme} withGlobalStyles withNormalizeCSS>
       <html lang="en">
         <head>
           <StylesPlaceholder />
@@ -119,7 +117,6 @@ export default function App() {
           <LiveReload />
         </body>
       </html>
-    </MantineProvider>
     );
   }
 

--- a/refine-remix/plugins/mantine/extend.js
+++ b/refine-remix/plugins/mantine/extend.js
@@ -5,29 +5,35 @@ const base = {
             `import { MantineProvider, Global, ColorScheme } from "@mantine/core";`,
             `import { NotificationsProvider } from "@mantine/notifications";`,
             `import { useLocalStorage } from "@mantine/hooks";`,
-            `import { ColorSchemeProvider } from "@mantine/styles";`
+            `import { ColorSchemeProvider } from "@mantine/styles";`,
         ],
-        refineMantineImports: [
-            "notificationProvider",
-            "DarkTheme",
-            "LightTheme",
-        ],
+        refineMantineImports: ["notificationProvider", "RefineThemes"],
         wrapper: [
-            ["<ColorSchemeProvider colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}>", "</ColorSchemeProvider>"],
-            [`<MantineProvider theme={colorScheme === "dark" ? DarkTheme : LightTheme} withNormalizeCSS withGlobalStyles>`, "</MantineProvider>"],
+            [
+                "<ColorSchemeProvider colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}>",
+                "</ColorSchemeProvider>",
+            ],
+            [
+                // You can change the theme colors here. example: theme={{ ...RefineThemes.Magenta, colorScheme:colorScheme }}
+                `<MantineProvider theme={{ ...RefineThemes.Blue, colorScheme:colorScheme }} withNormalizeCSS withGlobalStyles>`,
+                "</MantineProvider>",
+            ],
             [`<Global styles={{ body: { WebkitFontSmoothing: "auto" } }} />`],
-            [`<NotificationsProvider position="top-right">`, "</NotificationsProvider>"],
+            [
+                `<NotificationsProvider position="top-right">`,
+                "</NotificationsProvider>",
+            ],
         ],
         innerHooks: [
             `const [colorScheme, setColorScheme] = useLocalStorage<ColorScheme>({
                 key: "mantine-color-scheme",
                 defaultValue: "light",
                 getInitialValueInEffect: true,
-            });`
+            });`,
         ],
         inner: [
             `const toggleColorScheme = (value?: ColorScheme) =>
-            setColorScheme(value || (colorScheme === "dark" ? "light" : "dark"));`
+            setColorScheme(value || (colorScheme === "dark" ? "light" : "dark"));`,
         ],
         localImport: [],
     },

--- a/refine-remix/plugins/mui/app/components/header/index.tsx
+++ b/refine-remix/plugins/mui/app/components/header/index.tsx
@@ -11,7 +11,7 @@ import {
 import { RefineThemedLayoutHeaderProps } from "@refinedev/mui";
 import { DarkModeOutlined, LightModeOutlined, Menu } from "@mui/icons-material";
 
-import { ColorModeContext } from "@contexts";
+import { ColorModeContext } from "~/contexts/ColorModeContext";
 
 type IUser = {
     id: number;

--- a/refine-remix/plugins/mui/app/components/header/index.tsx
+++ b/refine-remix/plugins/mui/app/components/header/index.tsx
@@ -1,49 +1,97 @@
 import React, { useContext } from "react";
 import { useGetIdentity } from "@refinedev/core";
 import {
-  AppBar,
-  IconButton,
-  Avatar,
-  Stack,
-  Toolbar,
-  Typography,
+    AppBar,
+    IconButton,
+    Avatar,
+    Stack,
+    Toolbar,
+    Typography,
 } from "@mui/material";
-import { DarkModeOutlined, LightModeOutlined } from "@mui/icons-material";
+import { RefineThemedLayoutHeaderProps } from "@refinedev/mui";
+import { DarkModeOutlined, LightModeOutlined, Menu } from "@mui/icons-material";
 
 import { ColorModeContext } from "@contexts";
 
-export const Header: React.FC = () => {
-  const { mode, setMode } = useContext(ColorModeContext);
+type IUser = {
+    id: number;
+    name: string;
+    avatar: string;
+};
 
-  const { data: user } = useGetIdentity();
-  const showUserInfo = user && (user.name || user.avatar);
+export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
+    isSiderOpen,
+    onToggleSiderClick,
+    toggleSiderIcon: toggleSiderIconFromProps,
+}) => {
+    const { mode, setMode } = useContext(ColorModeContext);
 
-  return (
-    <AppBar color="default" position="sticky" elevation={1}>
-      <Toolbar>
-        <Stack
-            direction="row"
-            width="100%"
-            justifyContent="flex-end"
-            alignItems="center"
-        >
-          <IconButton
-            onClick={() => {
-              setMode();
-            }}
-          >
-            {mode === "dark" ? <LightModeOutlined /> : <DarkModeOutlined />}
-          </IconButton>
-          {showUserInfo && (
-            <Stack direction="row" gap="16px" alignItems="center">
-              {user.avatar && <Avatar src={user?.avatar} alt={user?.name} />}
-              {user.name && (
-                <Typography variant="subtitle2">{user?.name}</Typography>
-              )}
-            </Stack>
-          )}
-        </Stack>
-      </Toolbar>
-    </AppBar>
-  );
+    const { data: user } = useGetIdentity<IUser>();
+
+    const hasSidebarToggle = Boolean(onToggleSiderClick);
+
+    return (
+        <AppBar color="default" position="sticky">
+            <Toolbar>
+                <Stack
+                    direction="row"
+                    width="100%"
+                    justifyContent="flex-end"
+                    alignItems="center"
+                >
+                    {hasSidebarToggle && (
+                        <IconButton
+                            aria-label="open drawer"
+                            onClick={() => onToggleSiderClick?.()}
+                            edge="start"
+                            sx={{
+                                mr: 2,
+                                display: { xs: "none", md: "flex" },
+                                ...(isSiderOpen && { display: "none" }),
+                            }}
+                        >
+                            {toggleSiderIconFromProps?.(
+                                Boolean(isSiderOpen),
+                            ) ?? <Menu />}
+                        </IconButton>
+                    )}
+
+                    <Stack
+                        direction="row"
+                        width="100%"
+                        justifyContent="flex-end"
+                        alignItems="center"
+                    >
+                        <IconButton
+                            onClick={() => {
+                                setMode();
+                            }}
+                        >
+                            {mode === "dark" ? (
+                                <LightModeOutlined />
+                            ) : (
+                                <DarkModeOutlined />
+                            )}
+                        </IconButton>
+
+                        {(user?.avatar || user?.name) && (
+                            <Stack
+                                direction="row"
+                                gap="16px"
+                                alignItems="center"
+                                justifyContent="center"
+                            >
+                                {user?.name && (
+                                    <Typography variant="subtitle2">
+                                        {user?.name}
+                                    </Typography>
+                                )}
+                                <Avatar src={user?.avatar} alt={user?.name} />
+                            </Stack>
+                        )}
+                    </Stack>
+                </Stack>
+            </Toolbar>
+        </AppBar>
+    );
 };

--- a/refine-remix/plugins/mui/app/contexts/ClientStyleContext.ts
+++ b/refine-remix/plugins/mui/app/contexts/ClientStyleContext.ts
@@ -1,9 +1,0 @@
-import { createContext } from "react";
-
-export interface ClientStyleContextData {
-    reset: () => void;
-}
-
-export default createContext<ClientStyleContextData>({
-    reset: () => {},
-});

--- a/refine-remix/plugins/mui/app/contexts/ClientStyleContext.tsx
+++ b/refine-remix/plugins/mui/app/contexts/ClientStyleContext.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { CacheProvider } from "@emotion/react";
+import createCache from "@emotion/cache";
+
+export interface ClientStyleContextData {
+    reset: () => void;
+}
+
+interface ClientCacheProviderProps {
+    children: React.ReactNode;
+}
+
+export const ClientStyleContext = React.createContext<ClientStyleContextData>({
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    reset: () => {},
+});
+
+const createEmotionCache = () => {
+    return createCache({ key: "css" });
+};
+
+export const ClientStyleCacheProvider = ({
+    children,
+}: ClientCacheProviderProps) => {
+    const [cache, setCache] = React.useState(createEmotionCache());
+
+    const clientStyleContextValue = React.useMemo(
+        () => ({
+            reset() {
+                setCache(createEmotionCache());
+            },
+        }),
+        [],
+    );
+
+    return (
+        <ClientStyleContext.Provider value={clientStyleContextValue}>
+            <CacheProvider value={cache}>{children}</CacheProvider>
+        </ClientStyleContext.Provider>
+    );
+};

--- a/refine-remix/plugins/mui/app/contexts/ColorModeContext.tsx
+++ b/refine-remix/plugins/mui/app/contexts/ColorModeContext.tsx
@@ -1,13 +1,13 @@
+import { useMediaQuery } from "@mui/material";
+import { ThemeProvider } from "@mui/material/styles";
+import { RefineThemes } from "@refinedev/mui";
+import { parseCookies, setCookie } from "nookies";
 import React, {
     PropsWithChildren,
     createContext,
     useEffect,
     useState,
 } from "react";
-import { useMediaQuery } from "@mui/material";
-import { ThemeProvider } from "@mui/material/styles";
-import { RefineThemes } from "@refinedev/mui";
-import { parseCookies, setCookie } from "nookies";
 
 type ColorModeContextType = {
     mode: string;
@@ -44,8 +44,6 @@ export const ColorModeContextProvider: React.FC<PropsWithChildren> = ({
         setMode(nextTheme);
         setCookie(null, "theme", nextTheme);
     };
-
-    if (!isMounted) return null;
 
     return (
         <ColorModeContext.Provider

--- a/refine-remix/plugins/mui/app/contexts/index.ts
+++ b/refine-remix/plugins/mui/app/contexts/index.ts
@@ -1,0 +1,5 @@
+export {
+    ClientStyleCacheProvider,
+    ClientStyleContext,
+} from "./ClientStyleContext";
+export { ColorModeContext, ColorModeContextProvider } from "./ColorModeContext";

--- a/refine-remix/plugins/mui/app/contexts/index.tsx
+++ b/refine-remix/plugins/mui/app/contexts/index.tsx
@@ -6,7 +6,7 @@ import React, {
 } from "react";
 import { useMediaQuery } from "@mui/material";
 import { ThemeProvider } from "@mui/material/styles";
-import { DarkTheme, LightTheme } from "@refinedev/mui";
+import { RefineThemes } from "@refinedev/mui";
 import { parseCookies, setCookie } from "nookies";
 
 type ColorModeContextType = {
@@ -45,6 +45,8 @@ export const ColorModeContextProvider: React.FC<PropsWithChildren> = ({
         setCookie(null, "theme", nextTheme);
     };
 
+    if (!isMounted) return null;
+
     return (
         <ColorModeContext.Provider
             value={{
@@ -52,7 +54,12 @@ export const ColorModeContextProvider: React.FC<PropsWithChildren> = ({
                 mode,
             }}
         >
-            <ThemeProvider theme={mode === "light" ? LightTheme : DarkTheme}>
+            <ThemeProvider
+                // you can change the theme colors here. example: mode === "light" ? RefineThemes.Magenta : RefineThemes.MagentaDark
+                theme={
+                    mode === "light" ? RefineThemes.Blue : RefineThemes.BlueDark
+                }
+            >
                 {children}
             </ThemeProvider>
         </ColorModeContext.Provider>

--- a/refine-remix/plugins/mui/app/entry.client.tsx
+++ b/refine-remix/plugins/mui/app/entry.client.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
+import { RemixBrowser } from "@remix-run/react";
+import { CssBaseline, GlobalStyles } from "@mui/material";
+import { ClientStyleCacheProvider, ColorModeContextProvider } from "~/contexts";
+
+const hydrate = () => {
+    React.startTransition(() => {
+        ReactDOM.hydrateRoot(
+            document,
+            <ClientStyleCacheProvider>
+                <ColorModeContextProvider>
+                    <CssBaseline />
+                    <GlobalStyles
+                        styles={{ html: { WebkitFontSmoothing: "auto" } }}
+                    />
+                    <RemixBrowser />
+                </ColorModeContextProvider>
+            </ClientStyleCacheProvider>,
+        );
+    });
+};
+
+if (window.requestIdleCallback) {
+    window.requestIdleCallback(hydrate);
+} else {
+    // Safari doesn't support requestIdleCallback
+    // https://caniuse.com/requestidlecallback
+    window.setTimeout(hydrate, 1);
+}

--- a/refine-remix/plugins/mui/extend.js
+++ b/refine-remix/plugins/mui/extend.js
@@ -1,25 +1,21 @@
 const base = {
     _app: {
         import: [
-            `import { CssBaseline, GlobalStyles } from "@mui/material";`,
+            "import { withEmotionCache } from '@emotion/react';",
+            `import { CssBaseline, GlobalStyles , unstable_useEnhancedEffect as useEnhancedEffect} from "@mui/material";`,
         ],
         refineProps: ["notificationProvider={notificationProvider}"],
-        refineMuiImports: [
-            "notificationProvider",
-            "RefineSnackbarProvider",
-        ],
+        refineMuiImports: ["notificationProvider", "RefineSnackbarProvider"],
         localImport: [
             `import ClientStyleContext from '~/contexts/ClientStyleContext';`,
             `import { ColorModeContextProvider } from "~/contexts";`,
         ],
-        import: [
-            "import { withEmotionCache } from '@emotion/react';",
-            "import { unstable_useEnhancedEffect as useEnhancedEffect } from '@mui/material';",
-        ],
         wrapper: [
             ["<ColorModeContextProvider>", "</ColorModeContextProvider>"],
             ["<CssBaseline />"],
-            [`<GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />`],
+            [
+                `<GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />`,
+            ],
             ["<RefineSnackbarProvider>", "</RefineSnackbarProvider>"],
         ],
     },

--- a/refine-remix/plugins/mui/extend.js
+++ b/refine-remix/plugins/mui/extend.js
@@ -2,22 +2,12 @@ const base = {
     _app: {
         import: [
             "import { withEmotionCache } from '@emotion/react';",
-            `import { CssBaseline, GlobalStyles , unstable_useEnhancedEffect as useEnhancedEffect} from "@mui/material";`,
+            `import { unstable_useEnhancedEffect as useEnhancedEffect} from "@mui/material";`,
         ],
         refineProps: ["notificationProvider={notificationProvider}"],
         refineMuiImports: ["notificationProvider", "RefineSnackbarProvider"],
-        localImport: [
-            `import ClientStyleContext from '~/contexts/ClientStyleContext';`,
-            `import { ColorModeContextProvider } from "~/contexts";`,
-        ],
-        wrapper: [
-            ["<ColorModeContextProvider>", "</ColorModeContextProvider>"],
-            ["<CssBaseline />"],
-            [
-                `<GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />`,
-            ],
-            ["<RefineSnackbarProvider>", "</RefineSnackbarProvider>"],
-        ],
+        localImport: [`import { ClientStyleContext } from "~/contexts";`],
+        wrapper: [["<RefineSnackbarProvider>", "</RefineSnackbarProvider>"]],
     },
 };
 


### PR DESCRIPTION
refine-remix:

-   [x] antd, i18n-antd:

    -   [x] `<Layout>` updated to `<ThemedLayout>`.
    -   [x] `<Header>` copied from `<ThemedHeader>`.

-   [x] mui, 18n-mui:

    -   [x] `<Layout>` updated to `<ThemedLayout>`.
    -   [x] `<Header>` copied from `<ThemedHeader>`.

-   [x] chakra-ui, i18n-chakra-ui:

    -   [x] `<Layout>` updated to `<ThemedLayout>`.
    -   [x] `<Header>` copied from `<ThemedHeader>`.

-   [x] mantine, i18n-mantine:
    -   [x] `<Layout>` updated to `<ThemedLayout>`.
    -   [x] `<Header>` copied from `<ThemedHeader>`.


