### PR TITLE
fix(refine-nextjs): remove layout when headless selected

### DIFF
--- a/refine-nextjs/plugins/auth-provider-auth0/pages/_app.tsx
+++ b/refine-nextjs/plugins/auth-provider-auth0/pages/_app.tsx
@@ -185,11 +185,17 @@ function MyApp({ Component, pageProps: { session, ...pageProps }, }: AppPropsWit
             return <Component {...pageProps} />;
         }
 
-        return (
-            <ThemedLayout Header={Header}>
+        <%_ if (answers["ui-framework"] === "no") { _%>
+            return (
                 <Component {...pageProps} />
-            </ThemedLayout>
-        );
+            );
+            <%_ } else {_%>
+            return (
+                <ThemedLayout Header={Header}>
+                    <Component {...pageProps} />
+                </ThemedLayout>
+            );
+        <%_ } _%>
     };
 
     return (

--- a/refine-nextjs/plugins/auth-provider-google/pages/_app.tsx
+++ b/refine-nextjs/plugins/auth-provider-google/pages/_app.tsx
@@ -185,11 +185,17 @@ function MyApp({ Component, pageProps: { session, ...pageProps }, }: AppPropsWit
             return <Component {...pageProps} />;
         }
 
-        return (
-            <ThemedLayout Header={Header}>
+        <%_ if (answers["ui-framework"] === "no") { _%>
+            return (
                 <Component {...pageProps} />
-            </ThemedLayout>
-        );
+            );
+            <%_ } else {_%>
+            return (
+                <ThemedLayout Header={Header}>
+                    <Component {...pageProps} />
+                </ThemedLayout>
+            );
+        <%_ } _%>
     };
 
     return (

--- a/refine-nextjs/plugins/auth-provider-keycloak/pages/_app.tsx
+++ b/refine-nextjs/plugins/auth-provider-keycloak/pages/_app.tsx
@@ -185,11 +185,17 @@ function MyApp({ Component, pageProps: { session, ...pageProps }, }: AppPropsWit
             return <Component {...pageProps} />;
         }
 
-        return (
-            <ThemedLayout Header={Header}>
+        <%_ if (answers["ui-framework"] === "no") { _%>
+            return (
                 <Component {...pageProps} />
-            </ThemedLayout>
-        );
+            );
+            <%_ } else {_%>
+            return (
+                <ThemedLayout Header={Header}>
+                    <Component {...pageProps} />
+                </ThemedLayout>
+            );
+        <%_ } _%>
     };
 
     return (

--- a/refine-nextjs/template/pages/_app.tsx
+++ b/refine-nextjs/template/pages/_app.tsx
@@ -44,11 +44,17 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout): JSX.Element {
             return <Component {...pageProps} />;
         }
 
-        return (
-            <ThemedLayout Header={Header}>
+        <%_ if (answers["ui-framework"] === "no") { _%>
+            return (
                 <Component {...pageProps} />
-            </ThemedLayout>
-        );
+            );
+            <%_ } else {_%>
+            return (
+                <ThemedLayout Header={Header}>
+                    <Component {...pageProps} />
+                </ThemedLayout>
+            );
+        <%_ } _%>
     };
 
     <%- (_app.innerHooks || []).join("\n") %>


### PR DESCRIPTION
Fixed: when headless selected `(ui-framework === "no")`. `<ThemedLayout>` should not exist.