### PR TITLE
fix(mui): header color

### DIFF
--- a/refine-nextjs/plugins/i18n-mui/src/components/header/index.tsx
+++ b/refine-nextjs/plugins/i18n-mui/src/components/header/index.tsx
@@ -36,11 +36,12 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
     const hasSidebarToggle = Boolean(onToggleSiderClick);
 
     return (
-        <AppBar color="default" position="sticky">
+        <AppBar position="sticky">
             <Toolbar>
                 <Stack direction="row" width="100%" alignItems="center">
                     {hasSidebarToggle && (
                         <IconButton
+                            color="inherit"
                             aria-label="open drawer"
                             onClick={() => onToggleSiderClick?.()}
                             edge="start"
@@ -105,6 +106,7 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
                         </FormControl>
 
                         <IconButton
+                            color="inherit"
                             onClick={() => {
                                 setMode();
                             }}

--- a/refine-nextjs/plugins/mui/src/components/header/index.tsx
+++ b/refine-nextjs/plugins/mui/src/components/header/index.tsx
@@ -31,7 +31,7 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
     const hasSidebarToggle = Boolean(onToggleSiderClick);
 
     return (
-        <AppBar color="default" position="sticky">
+        <AppBar position="sticky">
             <Toolbar>
                 <Stack
                     direction="row"
@@ -41,6 +41,7 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
                 >
                     {hasSidebarToggle && (
                         <IconButton
+                            color="inherit"
                             aria-label="open drawer"
                             onClick={() => onToggleSiderClick?.()}
                             edge="start"
@@ -63,6 +64,7 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
                         alignItems="center"
                     >
                         <IconButton
+                            color="inherit"
                             onClick={() => {
                                 setMode();
                             }}

--- a/refine-react/plugins/i18n-mui/src/components/header/index.tsx
+++ b/refine-react/plugins/i18n-mui/src/components/header/index.tsx
@@ -40,11 +40,12 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
     const hasSidebarToggle = Boolean(onToggleSiderClick);
 
     return (
-        <AppBar color="default" position="sticky">
+        <AppBar position="sticky">
             <Toolbar>
                 <Stack direction="row" width="100%" alignItems="center">
                     {hasSidebarToggle && (
                         <IconButton
+                            color="inherit"
                             aria-label="open drawer"
                             onClick={() => onToggleSiderClick?.()}
                             edge="start"
@@ -109,6 +110,7 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
                         </FormControl>
 
                         <IconButton
+                            color="inherit"
                             onClick={() => {
                                 setMode();
                             }}

--- a/refine-react/plugins/mui/src/components/header/index.tsx
+++ b/refine-react/plugins/mui/src/components/header/index.tsx
@@ -31,7 +31,7 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
     const hasSidebarToggle = Boolean(onToggleSiderClick);
 
     return (
-        <AppBar color="default" position="sticky">
+        <AppBar position="sticky">
             <Toolbar>
                 <Stack
                     direction="row"
@@ -41,6 +41,7 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
                 >
                     {hasSidebarToggle && (
                         <IconButton
+                            color="inherit"
                             aria-label="open drawer"
                             onClick={() => onToggleSiderClick?.()}
                             edge="start"
@@ -63,6 +64,7 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
                         alignItems="center"
                     >
                         <IconButton
+                            color="inherit"
                             onClick={() => {
                                 setMode();
                             }}

--- a/refine-remix/plugins/mui/app/components/header/index.tsx
+++ b/refine-remix/plugins/mui/app/components/header/index.tsx
@@ -31,7 +31,7 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
     const hasSidebarToggle = Boolean(onToggleSiderClick);
 
     return (
-        <AppBar color="default" position="sticky">
+        <AppBar position="sticky">
             <Toolbar>
                 <Stack
                     direction="row"
@@ -41,6 +41,7 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
                 >
                     {hasSidebarToggle && (
                         <IconButton
+                            color="inherit"
                             aria-label="open drawer"
                             onClick={() => onToggleSiderClick?.()}
                             edge="start"
@@ -63,6 +64,7 @@ export const Header: React.FC<RefineThemedLayoutHeaderProps> = ({
                         alignItems="center"
                     >
                         <IconButton
+                            color="inherit"
                             onClick={() => {
                                 setMode();
                             }}


### PR DESCRIPTION
Fixed: `<Appbar>` "color="default" removed because it should primary color.

Added: `color="inherit"` to `IconButton` because `IconButton` has default colors but should be inherited from `<AppBar>` to get `contrastText` value