### PR TITLE
fix: use `menu`instead deprecated `overlay`

### DIFF
--- a/refine-nextjs/plugins/i18n-antd/src/components/header/index.tsx
+++ b/refine-nextjs/plugins/i18n-antd/src/components/header/index.tsx
@@ -8,10 +8,10 @@ import {
     Avatar,
     Typography,
     Switch,
-    Menu,
     Button,
     Dropdown,
     theme,
+    MenuProps,
 } from "antd";
 import { DownOutlined } from "@ant-design/icons";
 import { ColorModeContext } from "../../contexts";
@@ -35,27 +35,21 @@ export const Header: React.FC = () => {
     const { locales } = useRouter();
     const currentLocale = locale();
 
-    const menu = (
-        <Menu selectedKeys={currentLocale ? [currentLocale] : []}>
-            {[...(locales || [])].sort().map((lang: string) => (
-                <Menu.Item
-                    key={lang}
-                    icon={
-                        <span style={{ marginRight: 8 }}>
-                            <Avatar
-                                size={16}
-                                src={`/images/flags/${lang}.svg`}
-                            />
-                        </span>
-                    }
-                >
-                    <Link href="/" locale={lang}>
-                        {lang === "en" ? "English" : "German"}
-                    </Link>
-                </Menu.Item>
-            ))}
-        </Menu>
-    );
+    const menuItems: MenuProps["items"] = [...(locales || [])]
+        .sort()
+        .map((lang: string) => ({
+            key: lang,
+            icon: (
+                <span style={{ marginRight: 8 }}>
+                    <Avatar size={16} src={`/images/flags/${lang}.svg`} />
+                </span>
+            ),
+            label: (
+                <Link href="/" locale={lang}>
+                    {lang === "en" ? "English" : "German"}
+                </Link>
+            ),
+        }));
 
     return (
         <AntdLayout.Header
@@ -69,7 +63,12 @@ export const Header: React.FC = () => {
             }}
         >
             <Space>
-                <Dropdown overlay={menu}>
+                <Dropdown
+                    menu={{
+                        items: menuItems,
+                        selectedKeys: currentLocale ? [currentLocale] : [],
+                    }}
+                >
                     <Button type="text">
                         <Space>
                             <Avatar

--- a/refine-react/plugins/i18n-antd/src/components/header/index.tsx
+++ b/refine-react/plugins/i18n-antd/src/components/header/index.tsx
@@ -6,10 +6,10 @@ import {
     Avatar,
     Typography,
     Switch,
-    Menu,
     Button,
     Dropdown,
     theme,
+    MenuProps,
 } from "antd";
 import { DownOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
@@ -35,26 +35,18 @@ export const Header: React.FC = () => {
 
     const currentLocale = locale();
 
-    const menu = (
-        <Menu selectedKeys={currentLocale ? [currentLocale] : []}>
-            {[...(i18n.languages || [])].sort().map((lang: string) => (
-                <Menu.Item
-                    key={lang}
-                    onClick={() => changeLanguage(lang)}
-                    icon={
-                        <span style={{ marginRight: 8 }}>
-                            <Avatar
-                                size={16}
-                                src={`/images/flags/${lang}.svg`}
-                            />
-                        </span>
-                    }
-                >
-                    {lang === "en" ? "English" : "German"}
-                </Menu.Item>
-            ))}
-        </Menu>
-    );
+    const menuItems: MenuProps["items"] = [...(i18n.languages || [])]
+        .sort()
+        .map((lang: string) => ({
+            key: lang,
+            onClick: () => changeLanguage(lang),
+            icon: (
+                <span style={{ marginRight: 8 }}>
+                    <Avatar size={16} src={`/images/flags/${lang}.svg`} />
+                </span>
+            ),
+            label: lang === "en" ? "English" : "German",
+        }));
 
     return (
         <AntdLayout.Header
@@ -68,7 +60,12 @@ export const Header: React.FC = () => {
             }}
         >
             <Space>
-                <Dropdown overlay={menu}>
+                <Dropdown
+                    menu={{
+                        items: menuItems,
+                        selectedKeys: currentLocale ? [currentLocale] : [],
+                    }}
+                >
                     <Button type="text">
                         <Space>
                             <Avatar


### PR DESCRIPTION
Fixed deprecated `<Dropdown>` prop. To solve it,  used `menu` instead of deprecated `overlay`.