### PR TITLE
chore(mui-vite): update imports

### DIFF
--- a/refine-vite/plugins/auth-provider-auth0/src/pages/login.tsx
+++ b/refine-vite/plugins/auth-provider-auth0/src/pages/login.tsx
@@ -6,7 +6,10 @@ import { ThemedTitleV2 } from "@refinedev/antd";
 import { Button, Typography, Layout, Space } from "antd";
 <%_ } _%> 
 <%_ if (answers["ui-framework"] === 'mui') { _%>
-import { Box, Button, Container, Typography } from "@mui/material";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
+import Typography from "@mui/material/Typography";
 import { ThemedTitleV2 } from "@refinedev/mui";
 <%_ } _%>
 <%_ if (answers["ui-framework"] === 'mantine') { _%>

--- a/refine-vite/plugins/auth-provider-google/src/pages/login.tsx
+++ b/refine-vite/plugins/auth-provider-google/src/pages/login.tsx
@@ -6,7 +6,9 @@ import { ThemedTitleV2 } from "@refinedev/antd";
 import { Typography, Layout, Space } from "antd";
 <%_ } _%> 
 <%_ if (answers["ui-framework"] === 'mui') { _%>
-import { Box, Container, Typography } from "@mui/material";
+import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
+import Typography from "@mui/material/Typography";
 import { ThemedTitleV2 } from "@refinedev/mui";
 <%_ } _%>
 <%_ if (answers["ui-framework"] === 'mantine') { _%>

--- a/refine-vite/plugins/auth-provider-keycloak/src/pages/login.tsx
+++ b/refine-vite/plugins/auth-provider-keycloak/src/pages/login.tsx
@@ -4,7 +4,10 @@ import { ThemedTitleV2 } from "@refinedev/antd";
 import { Button, Typography, Layout, Space } from "antd";
 <%_ } _%> 
 <%_ if (answers["ui-framework"] === 'mui') { _%>
-import { Box, Button, Container, Typography } from "@mui/material";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Container from "@mui/material/Container";
+import Typography from "@mui/material/Typography";
 import { ThemedTitleV2 } from "@refinedev/mui";
 <%_ } _%>
 <%_ if (answers["ui-framework"] === 'mantine') { _%>

--- a/refine-vite/plugins/i18n-mui/src/components/header/index.tsx
+++ b/refine-vite/plugins/i18n-mui/src/components/header/index.tsx
@@ -1,15 +1,14 @@
-import { DarkModeOutlined, LightModeOutlined } from "@mui/icons-material";
-import {
-    AppBar,
-    Avatar,
-    FormControl,
-    IconButton,
-    MenuItem,
-    Select,
-    Stack,
-    Toolbar,
-    Typography,
-} from "@mui/material";
+import DarkModeOutlined from "@mui/icons-material/DarkModeOutlined";
+import LightModeOutlined from "@mui/icons-material/LightModeOutlined";
+import AppBar from "@mui/material/AppBar";
+import Avatar from "@mui/material/Avatar";
+import FormControl from "@mui/material/FormControl";
+import IconButton from "@mui/material/IconButton";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import Stack from "@mui/material/Stack";
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
 import { useGetIdentity, useGetLocale, useSetLocale } from "@refinedev/core";
 import { HamburgerMenu, RefineThemedLayoutV2HeaderProps } from "@refinedev/mui";
 import i18n from "i18next";

--- a/refine-vite/plugins/mui/extend.js
+++ b/refine-vite/plugins/mui/extend.js
@@ -1,7 +1,10 @@
 const base = {
     _app: {
         refineProps: ["notificationProvider={notificationProvider}"],
-        import: [`import { CssBaseline, GlobalStyles } from "@mui/material";`],
+        import: [
+            `import CssBaseline from "@mui/material/CssBaseline";`,
+            `import GlobalStyles from "@mui/material/GlobalStyles";`,
+        ],
         refineMuiImports: [
             "notificationProvider",
             "RefineSnackbarProvider",

--- a/refine-vite/plugins/mui/src/components/header/index.tsx
+++ b/refine-vite/plugins/mui/src/components/header/index.tsx
@@ -1,12 +1,11 @@
-import { DarkModeOutlined, LightModeOutlined } from "@mui/icons-material";
-import {
-    AppBar,
-    Avatar,
-    IconButton,
-    Stack,
-    Toolbar,
-    Typography,
-} from "@mui/material";
+import DarkModeOutlined from "@mui/icons-material/DarkModeOutlined";
+import LightModeOutlined from "@mui/icons-material/LightModeOutlined";
+import AppBar from "@mui/material/AppBar";
+import Avatar from "@mui/material/Avatar";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
 import { useGetIdentity } from "@refinedev/core";
 import { HamburgerMenu, RefineThemedLayoutV2HeaderProps } from "@refinedev/mui";
 import React, { useContext } from "react";


### PR DESCRIPTION
Updated imports for `@mui/material` and `@mui/icons-material` in `refine-vite` template.