### PR TITLE
fix: missing title on customized siders

### DIFF
--- a/refine-nextjs/plugins/auth-provider-auth0/pages/_app.tsx
+++ b/refine-nextjs/plugins/auth-provider-auth0/pages/_app.tsx
@@ -194,7 +194,7 @@ function MyApp({ Component, pageProps: { session, ...pageProps }, }: AppPropsWit
                 <ThemedLayoutV2
                     Header={() => <Header sticky />}
                     <%_ if (answers["ui-framework"] === 'antd') { _%>
-                    Sider={() => <ThemedSiderV2 fixed />}
+                    Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                     <%_ } _%>
                     <%_ if (selectedSvg || selectedTitle) { _%>
                     Title={({ collapsed }) => (

--- a/refine-nextjs/plugins/auth-provider-google/pages/_app.tsx
+++ b/refine-nextjs/plugins/auth-provider-google/pages/_app.tsx
@@ -194,7 +194,7 @@ function MyApp({ Component, pageProps: { session, ...pageProps }, }: AppPropsWit
                 <ThemedLayoutV2
                     Header={() => <Header sticky />}
                     <%_ if (answers["ui-framework"] === 'antd') { _%>
-                    Sider={() => <ThemedSiderV2 fixed />}
+                    Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                     <%_ } _%>
                     <%_ if (selectedSvg || selectedTitle) { _%>
                     Title={({ collapsed }) => (

--- a/refine-nextjs/plugins/auth-provider-keycloak/pages/_app.tsx
+++ b/refine-nextjs/plugins/auth-provider-keycloak/pages/_app.tsx
@@ -194,7 +194,7 @@ function MyApp({ Component, pageProps: { session, ...pageProps }, }: AppPropsWit
                 <ThemedLayoutV2
                     Header={() => <Header sticky />}
                     <%_ if (answers["ui-framework"] === 'antd') { _%>
-                    Sider={() => <ThemedSiderV2 fixed />}
+                    Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                     <%_ } _%>
                     <%_ if (selectedSvg || selectedTitle) { _%>
                     Title={({ collapsed }) => (

--- a/refine-nextjs/template/pages/_app.tsx
+++ b/refine-nextjs/template/pages/_app.tsx
@@ -55,7 +55,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout): JSX.Element {
                 <ThemedLayoutV2
                     Header={() => <Header sticky />}
                     <%_ if (answers["ui-framework"] === 'antd') { _%>
-                    Sider={() => <ThemedSiderV2 fixed />}
+                    Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                     <%_ } _%>
                     <%_ if (selectedSvg || selectedTitle) { _%>
                     Title={({ collapsed }) => (

--- a/refine-remix/plugins/auth-provider-auth0/app/routes/_layout.tsx
+++ b/refine-remix/plugins/auth-provider-auth0/app/routes/_layout.tsx
@@ -56,7 +56,7 @@ export default function BaseLayout() {
                 <ThemedLayoutV2
                     Header={() => <Header sticky />}
                     <%_ if (answers["ui-framework"] === 'antd') { _%>
-                    Sider={() => <ThemedSiderV2 fixed />}
+                    Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                     <%_ } _%>
                     <%_ if (selectedSvg || selectedTitle) { _%>
                     Title={({ collapsed }) => (

--- a/refine-remix/plugins/auth-provider-custom/app/routes/_layout.tsx
+++ b/refine-remix/plugins/auth-provider-custom/app/routes/_layout.tsx
@@ -55,7 +55,7 @@ export default function BaseLayout() {
                 <ThemedLayoutV2
                     Header={() => <Header sticky />}
                     <%_ if (answers["ui-framework"] === 'antd') { _%>
-                    Sider={() => <ThemedSiderV2 fixed />}
+                    Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                     <%_ } _%>
                     <%_ if (selectedSvg || selectedTitle) { _%>
                     Title={({ collapsed }) => (

--- a/refine-remix/plugins/auth-provider-google/app/routes/_layout.tsx
+++ b/refine-remix/plugins/auth-provider-google/app/routes/_layout.tsx
@@ -55,7 +55,7 @@ export default function BaseLayout() {
                 <ThemedLayoutV2
                     Header={() => <Header sticky />}
                     <%_ if (answers["ui-framework"] === 'antd') { _%>
-                    Sider={() => <ThemedSiderV2 fixed />}
+                    Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                     <%_ } _%>
                     <%_ if (selectedSvg || selectedTitle) { _%>
                     Title={({ collapsed }) => (

--- a/refine-remix/plugins/auth-provider-keycloak/app/routes/_layout.tsx
+++ b/refine-remix/plugins/auth-provider-keycloak/app/routes/_layout.tsx
@@ -55,7 +55,7 @@ export default function BaseLayout() {
                 <ThemedLayoutV2
                     Header={() => <Header sticky />}
                     <%_ if (answers["ui-framework"] === 'antd') { _%>
-                    Sider={() => <ThemedSiderV2 fixed />}
+                    Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                     <%_ } _%>
                     <%_ if (selectedSvg || selectedTitle) { _%>
                     Title={({ collapsed }) => (

--- a/refine-remix/plugins/data-provider-appwrite/app/routes/_layout.tsx
+++ b/refine-remix/plugins/data-provider-appwrite/app/routes/_layout.tsx
@@ -55,7 +55,7 @@ export default function BaseLayout() {
                 <ThemedLayoutV2
                     Header={() => <Header sticky />}
                     <%_ if (answers["ui-framework"] === 'antd') { _%>
-                    Sider={() => <ThemedSiderV2 fixed />}
+                    Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                     <%_ } _%>
                     <%_ if (selectedSvg || selectedTitle) { _%>
                     Title={({ collapsed }) => (

--- a/refine-remix/plugins/data-provider-strapi-v4/app/routes/_layout.tsx
+++ b/refine-remix/plugins/data-provider-strapi-v4/app/routes/_layout.tsx
@@ -55,7 +55,7 @@ export default function BaseLayout() {
                 <ThemedLayoutV2
                     Header={() => <Header sticky />}
                     <%_ if (answers["ui-framework"] === 'antd') { _%>
-                    Sider={() => <ThemedSiderV2 fixed />}
+                    Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                     <%_ } _%>
                     <%_ if (selectedSvg || selectedTitle) { _%>
                     Title={({ collapsed }) => (

--- a/refine-remix/plugins/data-provider-supabase/app/routes/_layout.tsx
+++ b/refine-remix/plugins/data-provider-supabase/app/routes/_layout.tsx
@@ -55,7 +55,7 @@ export default function BaseLayout() {
                 <ThemedLayoutV2
                     Header={() => <Header sticky />}
                     <%_ if (answers["ui-framework"] === 'antd') { _%>
-                    Sider={() => <ThemedSiderV2 fixed />}
+                    Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                     <%_ } _%>
                     <%_ if (selectedSvg || selectedTitle) { _%>
                     Title={({ collapsed }) => (

--- a/refine-remix/plugins/inferencer/app/routes/_layout.tsx
+++ b/refine-remix/plugins/inferencer/app/routes/_layout.tsx
@@ -59,7 +59,7 @@ export default function BaseLayout() {
                 <ThemedLayoutV2
                     Header={() => <Header sticky />}
                     <%_ if (answers["ui-framework"] === 'antd') { _%>
-                    Sider={() => <ThemedSiderV2 fixed />}
+                    Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                     <%_ } _%>
                     <%_ if (selectedSvg || selectedTitle) { _%>
                     Title={({ collapsed }) => (

--- a/refine-vite/template/src/App.tsx
+++ b/refine-vite/template/src/App.tsx
@@ -102,7 +102,7 @@ function App() {
                                     <ThemedLayoutV2
                                         Header={() => <Header sticky />}
                                         <%_ if (answers["ui-framework"] === 'antd') { _%>
-                                        Sider={() => <ThemedSiderV2 fixed />}
+                                        Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                                         <%_ } _%>
                                         <%_ if (selectedSvg || selectedTitle) { _%>
                                         Title={({ collapsed }) => (
@@ -206,7 +206,7 @@ function App() {
                                 <ThemedLayoutV2
                                     Header={() => <Header sticky />}
                                     <%_ if (answers["ui-framework"] === 'antd') { _%>
-                                    Sider={() => <ThemedSiderV2 fixed />}
+                                    Sider={(props) => <ThemedSiderV2 {...props} fixed />}
                                     <%_ } _%>
                                     <%_ if (selectedSvg || selectedTitle) { _%>
                                     Title={({ collapsed }) => (


### PR DESCRIPTION
This fixes the issue of icon and title not changing dynamically in refine's interactive templates. The provided `ThemedTitleV2` components were not used by the provided `ThemedSiderV2` since the props were not passed properly.