### PR TITLE
fix(nextjs-antd): remove transpilePackages

### DIFF
--- a/refine-nextjs/template/next.config.js
+++ b/refine-nextjs/template/next.config.js
@@ -5,34 +5,12 @@
         i18n, experimental: {
             newNextLinkBehavior: true,
         },
-        transpilePackages: [
-            '@refinedev/antd',
-            "@refinedev/inferencer",
-            'antd',
-            '@ant-design/pro-components',
-            '@ant-design/pro-layout',
-            '@ant-design/pro-utils',
-            '@ant-design/pro-provider',
-            'rc-pagination',
-            'rc-picker'
-        ],
     };
 <%_ } else if (answers["ui-framework"] === "antd" && answers[`i18n-${answers["ui-framework"]}`] === "no") { _%>
     module.exports = {
         experimental: {
             newNextLinkBehavior: true,
         },
-        transpilePackages: [
-            '@refinedev/antd',
-            "@refinedev/inferencer",
-            'antd',
-            '@ant-design/pro-components',
-            '@ant-design/pro-layout',
-            '@ant-design/pro-utils',
-            '@ant-design/pro-provider',
-            'rc-pagination',
-            'rc-picker'
-        ],
     };
 <%_ } else if (answers[`i18n-${answers["ui-framework"]}`] !== "no") { _%>
     const { i18n } = require("./next-i18next.config");


### PR DESCRIPTION
when next config has `transpilePackages`, npm run dev throws this error. to fix this we remove `transpilePackages`

![e91cd65a-204e-42d5-b37a-5fa0a8264bc5](https://github.com/pankod/superplate-core-plugins/assets/23058882/158dd865-dae2-48cf-865c-a45ef7fa785a)
