### PR TITLE
fix(remix-refine): deprecated hydrate error

### DIFF
--- a/refine-remix/plugins/chakra/app/entry.client.tsx
+++ b/refine-remix/plugins/chakra/app/entry.client.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { hydrate } from 'react-dom'
+import { hydrateRoot } from 'react-dom/client'
 import { CacheProvider } from '@emotion/react'
 import { RemixBrowser } from '@remix-run/react'
 
@@ -24,9 +24,9 @@ function ClientCacheProvider({ children }: ClientCacheProviderProps) {
   )
 }
 
-hydrate(
+hydrateRoot(
+  document,
   <ClientCacheProvider>
     <RemixBrowser />
-  </ClientCacheProvider>,
-  document,
+  </ClientCacheProvider>
 )


### PR DESCRIPTION
fixed : react-dom.development.js:86 Warning: ReactDOM.hydrate is no longer supported in React 18. Use hydrateRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot