### PR TITLE
feat: use new antd notification provider

### DIFF
--- a/refine-nextjs/plugins/antd/extend.js
+++ b/refine-nextjs/plugins/antd/extend.js
@@ -1,14 +1,18 @@
 const base = {
     _app: {
-        refineProps: ["notificationProvider={notificationProvider}"],
-        import: ['import "@refinedev/antd/dist/reset.css";'],
+        refineProps: ["notificationProvider={useNotificationProvider}"],
+        import: [
+            `import { App as AntdApp } from "antd"`,
+            'import "@refinedev/antd/dist/reset.css";',
+        ],
         refineAntdImports: [
-            "notificationProvider",
+            "useNotificationProvider",
             "ThemedLayoutV2",
             "ThemedSiderV2",
         ],
         wrapper: [
             [`<ColorModeContextProvider>`, `</ColorModeContextProvider>`],
+            [`<AntdApp>`, `</AntdApp>`],
         ],
         localImport: [
             `import { Header } from "@components/header"`,

--- a/refine-react/plugins/antd/extend.js
+++ b/refine-react/plugins/antd/extend.js
@@ -1,11 +1,12 @@
 const base = {
     _app: {
-        import: [],
+        import: [`import { App as AntdApp } from "antd"`],
         refineImports: [],
-        refineAntdImports: ["notificationProvider", "ThemedLayoutV2"],
-        refineProps: ["notificationProvider={notificationProvider}"],
+        refineAntdImports: ["useNotificationProvider", "ThemedLayoutV2"],
+        refineProps: ["notificationProvider={useNotificationProvider}"],
         wrapper: [
             [`<ColorModeContextProvider>`, `</ColorModeContextProvider>`],
+            [`<AntdApp>`, `</AntdApp>`],
         ],
         localImport: [
             `import { ColorModeContextProvider } from "./contexts/color-mode";`,

--- a/refine-remix/plugins/antd/extend.js
+++ b/refine-remix/plugins/antd/extend.js
@@ -1,11 +1,15 @@
 const base = {
     _app: {
-        refineProps: ["notificationProvider={notificationProvider}"],
-        import: ['import resetStyle from "@refinedev/antd/dist/reset.css";'],
-        refineAntdImports: ["notificationProvider"],
+        refineProps: ["notificationProvider={useNotificationProvider}"],
+        import: [
+            `import { App as AntdApp } from "antd"`,
+            'import resetStyle from "@refinedev/antd/dist/reset.css";',
+        ],
+        refineAntdImports: ["useNotificationProvider"],
         styleImport: ['{ rel: "stylesheet", href: resetStyle }'],
         wrapper: [
             [`<ColorModeContextProvider>`, `</ColorModeContextProvider>`],
+            [`<AntdApp>`, `</AntdApp>`],
         ],
         localImport: [`import { ColorModeContextProvider } from "@contexts";`],
     },

--- a/refine-vite/plugins/antd/extend.js
+++ b/refine-vite/plugins/antd/extend.js
@@ -1,15 +1,16 @@
 const base = {
     _app: {
-        import: [],
+        import: [`import { App as AntdApp } from "antd"`],
         refineImports: [],
         refineAntdImports: [
-            "notificationProvider",
+            "useNotificationProvider",
             "ThemedLayoutV2",
             "ThemedSiderV2",
         ],
-        refineProps: ["notificationProvider={notificationProvider}"],
+        refineProps: ["notificationProvider={useNotificationProvider}"],
         wrapper: [
             [`<ColorModeContextProvider>`, `</ColorModeContextProvider>`],
+            [`<AntdApp>`, `</AntdApp>`],
         ],
         localImport: [
             `import { ColorModeContextProvider } from "./contexts/color-mode";`,


### PR DESCRIPTION
feat: Removed deprecated `@refinedev/antd notificationProvider` and added the new `@refinedev/antd useNotificationProvider`.
