### PR TITLE
chore(refine-nextjs): remove redundant experimental config

### DIFF
--- a/refine-nextjs/template/next.config.js
+++ b/refine-nextjs/template/next.config.js
@@ -2,29 +2,17 @@
     const { i18n } = require("./next-i18next.config");
 
     module.exports = {
-        i18n, experimental: {
-            newNextLinkBehavior: true,
-        },
+        i18n,
     };
 <%_ } else if (answers["ui-framework"] === "antd" && answers[`i18n-${answers["ui-framework"]}`] === "no") { _%>
-    module.exports = {
-        experimental: {
-            newNextLinkBehavior: true,
-        },
-    };
+    module.exports = {};
 <%_ } else if (answers[`i18n-${answers["ui-framework"]}`] !== "no") { _%>
     const { i18n } = require("./next-i18next.config");
 
     module.exports = {
-        i18n, experimental: {
-            newNextLinkBehavior: true,
-        },
+        i18n,
     };
 <%_ } else { _%>
-    module.exports = {
-        experimental: {
-            newNextLinkBehavior: true,
-        },
-    };
+    module.exports = {};
 <%_ } _%>
 


### PR DESCRIPTION
Remove `experimental.newNextLinkBehavior` since it's now the default and having this config causes a warning to shown on development server.