### PR TITLE
chore(refine): add `useNewQueryKeys: true` to options

### DIFF
--- a/refine-nextjs/plugins/_base/src/components/menu/index.tsx
+++ b/refine-nextjs/plugins/_base/src/components/menu/index.tsx
@@ -18,7 +18,7 @@ export const Menu = () => {
                 {menuItems.map((item) => (
                     <li key={item.key}>
                         <Link
-                            href={item.route}
+                            href={item.route ?? "/"}
                             className={selectedKey === item.key ? "active" : ""}
                         >
                             {item.label}

--- a/refine-nextjs/plugins/auth-provider-auth0/pages/_app.tsx
+++ b/refine-nextjs/plugins/auth-provider-auth0/pages/_app.tsx
@@ -167,6 +167,9 @@ export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
                     syncWithLocation: true,
                     warnWhenUnsavedChanges: true,
                     useNewQueryKeys: true,
+                    <%_ if (typeof projectId !== 'undefined' && projectId !== '') { _%>
+                        projectId: "<%= projectId %>",
+                    <%_ } _%>
                 }}
             >
                 {props.children}

--- a/refine-nextjs/plugins/auth-provider-auth0/pages/_app.tsx
+++ b/refine-nextjs/plugins/auth-provider-auth0/pages/_app.tsx
@@ -166,6 +166,7 @@ export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
                 options={{
                     syncWithLocation: true,
                     warnWhenUnsavedChanges: true,
+                    useNewQueryKeys: true,
                 }}
             >
                 {props.children}

--- a/refine-nextjs/plugins/auth-provider-google/pages/_app.tsx
+++ b/refine-nextjs/plugins/auth-provider-google/pages/_app.tsx
@@ -167,6 +167,9 @@ export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
                     syncWithLocation: true,
                     warnWhenUnsavedChanges: true,
                     useNewQueryKeys: true,
+                    <%_ if (typeof projectId !== 'undefined' && projectId !== '') { _%>
+                        projectId: "<%= projectId %>",
+                    <%_ } _%>
                 }}
             >
                 {props.children}

--- a/refine-nextjs/plugins/auth-provider-google/pages/_app.tsx
+++ b/refine-nextjs/plugins/auth-provider-google/pages/_app.tsx
@@ -166,6 +166,7 @@ export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
                 options={{
                     syncWithLocation: true,
                     warnWhenUnsavedChanges: true,
+                    useNewQueryKeys: true,
                 }}
             >
                 {props.children}

--- a/refine-nextjs/plugins/auth-provider-keycloak/pages/_app.tsx
+++ b/refine-nextjs/plugins/auth-provider-keycloak/pages/_app.tsx
@@ -167,6 +167,9 @@ export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
                     syncWithLocation: true,
                     warnWhenUnsavedChanges: true,
                     useNewQueryKeys: true,
+                    <%_ if (typeof projectId !== 'undefined' && projectId !== '') { _%>
+                        projectId: "<%= projectId %>",
+                    <%_ } _%>
                 }}
             >
                 {props.children}

--- a/refine-nextjs/plugins/auth-provider-keycloak/pages/_app.tsx
+++ b/refine-nextjs/plugins/auth-provider-keycloak/pages/_app.tsx
@@ -166,6 +166,7 @@ export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
                 options={{
                     syncWithLocation: true,
                     warnWhenUnsavedChanges: true,
+                    useNewQueryKeys: true,
                 }}
             >
                 {props.children}

--- a/refine-nextjs/template/pages/_app.tsx
+++ b/refine-nextjs/template/pages/_app.tsx
@@ -139,6 +139,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout): JSX.Element {
                     options={{
                         syncWithLocation: true,
                         warnWhenUnsavedChanges: true,
+                        useNewQueryKeys: true,
                         <%_ if (typeof projectId !== 'undefined' && projectId !== '') { _%>
                             projectId: "<%= projectId %>",
                         <%_ } _%>

--- a/refine-react/plugins/_base/src/components/menu/index.tsx
+++ b/refine-react/plugins/_base/src/components/menu/index.tsx
@@ -18,7 +18,7 @@ export const Menu = () => {
                 {menuItems.map((item) => (
                     <li key={item.key}>
                         <NavLink
-                            to={item.route}
+                            to={item.route ?? "/"}
                         >
                             {item.label}
                         </NavLink>

--- a/refine-react/template/public/index.html
+++ b/refine-react/template/public/index.html
@@ -6,8 +6,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#000000" />
         <meta name="description" content="refine | Build your React-based CRUD applications, without constraints." />
-        <meta data-rh="true" property="og:image" content="https://refine.dev/img/refine_social_new.png" />
-        <meta data-rh="true" name="twitter:image" content="https://refine.dev/img/refine_social_new.png" />
+        <meta data-rh="true" property="og:image" content="https://refine.dev/img/refine_social.png" />
+        <meta data-rh="true" name="twitter:image" content="https://refine.dev/img/refine_social.png" />
         <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/refine-react/template/src/App.tsx
+++ b/refine-react/template/src/App.tsx
@@ -87,6 +87,7 @@ function App() {
                     options={{
                         syncWithLocation: true,
                         warnWhenUnsavedChanges: true,
+                        useNewQueryKeys: true,
                         <%_ if (typeof projectId !== 'undefined' && projectId !== '') { _%>
                             projectId: "<%= projectId %>",
                         <%_ } _%>

--- a/refine-remix/plugins/_base/app/components/menu/index.tsx
+++ b/refine-remix/plugins/_base/app/components/menu/index.tsx
@@ -18,7 +18,7 @@ export const Menu = () => {
                 {menuItems.map((item) => (
                     <li key={item.key}>
                         <NavLink
-                            to={item.route}
+                            to={item.route ?? "/"}
                         >
                             {item.label}
                         </NavLink>

--- a/refine-remix/plugins/chakra/app/root.tsx
+++ b/refine-remix/plugins/chakra/app/root.tsx
@@ -153,6 +153,9 @@ export default function App() {
                 syncWithLocation: true,
                 warnWhenUnsavedChanges: true,
                 useNewQueryKeys: true,
+                <%_ if (typeof projectId !== 'undefined' && projectId !== '') { _%>
+                  projectId: "<%= projectId %>",
+                <%_ } _%>
             }}
         >
           <Outlet />

--- a/refine-remix/plugins/chakra/app/root.tsx
+++ b/refine-remix/plugins/chakra/app/root.tsx
@@ -152,6 +152,7 @@ export default function App() {
             options={{
                 syncWithLocation: true,
                 warnWhenUnsavedChanges: true,
+                useNewQueryKeys: true,
             }}
         >
           <Outlet />

--- a/refine-remix/plugins/mantine/app/root.tsx
+++ b/refine-remix/plugins/mantine/app/root.tsx
@@ -105,6 +105,9 @@ export default function App() {
                 syncWithLocation: true,
                 warnWhenUnsavedChanges: true,
                 useNewQueryKeys: true,
+                <%_ if (typeof projectId !== 'undefined' && projectId !== '') { _%>
+                  projectId: "<%= projectId %>",
+                <%_ } _%>
             }}
                   >
                     <Outlet />

--- a/refine-remix/plugins/mantine/app/root.tsx
+++ b/refine-remix/plugins/mantine/app/root.tsx
@@ -104,6 +104,7 @@ export default function App() {
             options={{
                 syncWithLocation: true,
                 warnWhenUnsavedChanges: true,
+                useNewQueryKeys: true,
             }}
                   >
                     <Outlet />

--- a/refine-remix/plugins/mui/app/root.tsx
+++ b/refine-remix/plugins/mui/app/root.tsx
@@ -145,6 +145,9 @@ export default function App() {
                 syncWithLocation: true,
                 warnWhenUnsavedChanges: true,
                 useNewQueryKeys: true,
+                <%_ if (typeof projectId !== 'undefined' && projectId !== '') { _%>
+                  projectId: "<%= projectId %>",
+                <%_ } _%>
             }}
             >
               <Outlet />

--- a/refine-remix/plugins/mui/app/root.tsx
+++ b/refine-remix/plugins/mui/app/root.tsx
@@ -144,6 +144,7 @@ export default function App() {
             options={{
                 syncWithLocation: true,
                 warnWhenUnsavedChanges: true,
+                useNewQueryKeys: true,
             }}
             >
               <Outlet />

--- a/refine-remix/template/app/root.tsx
+++ b/refine-remix/template/app/root.tsx
@@ -104,6 +104,7 @@ export default function App() {
                             options={{
                                 syncWithLocation: true,
                                 warnWhenUnsavedChanges: true,
+                                useNewQueryKeys: true,
                                 <%_ if (typeof projectId !== 'undefined' && projectId !== '') { _%>
                                     projectId: "<%= projectId %>",
                                 <%_ } _%>

--- a/refine-vite/plugins/_base/src/components/menu/index.tsx
+++ b/refine-vite/plugins/_base/src/components/menu/index.tsx
@@ -18,7 +18,7 @@ export const Menu = () => {
                 {menuItems.map((item) => (
                     <li key={item.key}>
                         <NavLink
-                            to={item.route}
+                            to={item.route ?? "/"}
                         >
                             {item.label}
                         </NavLink>

--- a/refine-vite/template/index.html
+++ b/refine-vite/template/index.html
@@ -12,12 +12,12 @@
         <meta
             data-rh="true"
             property="og:image"
-            content="https://refine.dev/img/refine_social_new.png"
+            content="https://refine.dev/img/refine_social.png"
         />
         <meta
             data-rh="true"
             name="twitter:image"
-            content="https://refine.dev/img/refine_social_new.png"
+            content="https://refine.dev/img/refine_social.png"
         />
         <title>
             refine - Build your React-based CRUD applications, without

--- a/refine-vite/template/src/App.tsx
+++ b/refine-vite/template/src/App.tsx
@@ -87,6 +87,7 @@ function App() {
                     options={{
                         syncWithLocation: true,
                         warnWhenUnsavedChanges: true,
+                        useNewQueryKeys: true,
                         <%_ if (typeof projectId !== 'undefined' && projectId !== '') { _%>
                             projectId: "<%= projectId %>",
                         <%_ } _%>


### PR DESCRIPTION
Added `useNewQueryKeys: true` to the `<Refine>` component options to enable new structure for the query keys by default.

Also added missing `projectId` property to some templates.