### PR TITLE
feat: add transpile packages to nextjs

### DIFF
--- a/refine-nextjs/template/next.config.js
+++ b/refine-nextjs/template/next.config.js
@@ -1,18 +1,59 @@
-<%_if (answers["ui-framework"] === "antd" && answers[`i18n-${answers["ui-framework"]}`] !== "no") {_%>
+<%# https://github.com/refinedev/refine/issues/5197 %>
+<%# We need to add @refinedev/nextjs-router to the next.config.js#transpilePackages to avoid ssr mismatches. %>
+
+<%# https://github.com/refinedev/refine/issues/4998 %>
+<%# Also if user selects ant design we need to add @refinedev/antd and if they selected example pages (inferencer is installed) we can add @refinedev/inferencer as well. %>
+
+<%_if (answers["ui-framework"] === "antd" && answers["inferencer"] === 'inferencer' && answers[`i18n-${answers["ui-framework"]}`] !== "no") {_%>
     const { i18n } = require("./next-i18next.config");
 
     module.exports = {
         i18n,
+        transpilePackages: [
+            "@refinedev/nextjs-router", 
+            "@refinedev/antd",
+            "@refinedev/inferencer",
+        ],
     };
-<%_ } else if (answers["ui-framework"] === "antd" && answers[`i18n-${answers["ui-framework"]}`] === "no") { _%>
-    module.exports = {};
+<%_ } else if (answers["ui-framework"] === "antd" && answers["inferencer"] === 'no' && answers[`i18n-${answers["ui-framework"]}`] !== "no") { _%>
+    const { i18n } = require("./next-i18next.config");
+
+    module.exports = {
+        i18n,
+        transpilePackages: [
+            "@refinedev/nextjs-router", 
+            "@refinedev/antd",
+        ],
+    };
+<%_ } else if (answers["ui-framework"] === "antd" && answers["inferencer"] === 'inferencer' && answers[`i18n-${answers["ui-framework"]}`] === "no") { _%>
+    module.exports = {
+        transpilePackages: [
+          "@refinedev/nextjs-router", 
+          "@refinedev/antd",
+          "@refinedev/inferencer",
+        ],
+      };
+<%_ } else if (answers["ui-framework"] === "antd" && answers["inferencer"] === 'no' && answers[`i18n-${answers["ui-framework"]}`] === "no") { _%>
+    module.exports = {
+        transpilePackages: [
+          "@refinedev/nextjs-router", 
+          "@refinedev/antd",
+        ],
+      };
 <%_ } else if (answers[`i18n-${answers["ui-framework"]}`] !== "no") { _%>
     const { i18n } = require("./next-i18next.config");
 
     module.exports = {
         i18n,
+        transpilePackages: [
+            "@refinedev/nextjs-router", 
+        ],
     };
 <%_ } else { _%>
-    module.exports = {};
+    module.exports = {
+        transpilePackages: [
+            "@refinedev/nextjs-router", 
+        ],
+    };
 <%_ } _%>
 


### PR DESCRIPTION
To avoid ssr mismatches:
- add: @refinedev/nextjs-router to the next.config.js#transpilePackages
    - https://github.com/refinedev/refine/issues/5197
- add: @refinedev/antd and refinedev/inferencer to the next.config.js#transpilePackages
    - https://github.com/refinedev/refine/issues/4998


When antd is True:

  - inferencer True, antd True, i18n True
  ```md 
      module.exports = {
          i18n,
          transpilePackages: [
              "@refinedev/nextjs-router", 
              "@refinedev/antd",
              "@refinedev/inferencer",
          ],
      };
  ```

  - inferencer False, antd True, i18n True
  ```md 
      module.exports = {
          i18n,
          transpilePackages: [
              "@refinedev/nextjs-router", 
              "@refinedev/antd",
          ],
      };
  ```

  inferencer True, antd True, i18n False
  ```md 
      module.exports = {
          transpilePackages: [
              "@refinedev/nextjs-router", 
              "@refinedev/antd",
              "@refinedev/inferencer",
          ],
      };
  ```

  inferencer False, antd True, i18n False
  ```md 
      module.exports = {
          transpilePackages: [
              "@refinedev/nextjs-router", 
              "@refinedev/antd",
          ],
      };
  ```

When antd is False (In this case, inferencer is always False):

  antd False, inferencer False, i18n True
  ```md 
      module.exports = {
        i18n,
      };
  ```
  antd False, inferencer False, i18n False
  ```md 
      module.exports = {};
  ```

