### PR TITLE
chore: remove IResourceComponentProps type and usage

### DIFF
--- a/refine-nextjs/plugins/antd-example/src/app/blog-posts/create/page.tsx
+++ b/refine-nextjs/plugins/antd-example/src/app/blog-posts/create/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Create, useForm, useSelect } from "@refinedev/antd";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Form, Input, Select } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-nextjs/plugins/antd-example/src/app/blog-posts/edit/[id]/page.tsx
+++ b/refine-nextjs/plugins/antd-example/src/app/blog-posts/edit/[id]/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Edit, useForm, useSelect } from "@refinedev/antd";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Form, Input, Select } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-nextjs/plugins/antd-example/src/app/blog-posts/page.tsx
+++ b/refine-nextjs/plugins/antd-example/src/app/blog-posts/page.tsx
@@ -9,7 +9,7 @@ import {
     ShowButton,
     useTable,
 } from "@refinedev/antd";
-import { BaseRecord, IResourceComponentsProps, useMany } from "@refinedev/core";
+import { BaseRecord, useMany } from "@refinedev/core";
 import { Space, Table } from "antd";
 import React from "react";
     

--- a/refine-nextjs/plugins/antd-example/src/app/blog-posts/show/[id]/page.tsx
+++ b/refine-nextjs/plugins/antd-example/src/app/blog-posts/show/[id]/page.tsx
@@ -7,7 +7,7 @@ import {
     Show,
     TextField,
 } from "@refinedev/antd";
-import { IResourceComponentsProps, useOne, useShow } from "@refinedev/core";
+import { useOne, useShow } from "@refinedev/core";
 import { Typography } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-nextjs/plugins/antd-example/src/app/categories/create/page.tsx
+++ b/refine-nextjs/plugins/antd-example/src/app/categories/create/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Create, useForm } from "@refinedev/antd";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Form, Input } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-nextjs/plugins/antd-example/src/app/categories/edit/[id]/page.tsx
+++ b/refine-nextjs/plugins/antd-example/src/app/categories/edit/[id]/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Edit, useForm } from "@refinedev/antd";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Form, Input } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-nextjs/plugins/antd-example/src/app/categories/page.tsx
+++ b/refine-nextjs/plugins/antd-example/src/app/categories/page.tsx
@@ -7,7 +7,7 @@ import {
     ShowButton,
     useTable,
 } from "@refinedev/antd";
-import { BaseRecord, IResourceComponentsProps } from "@refinedev/core";
+import { BaseRecord } from "@refinedev/core";
 import { Space, Table } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-nextjs/plugins/antd-example/src/app/categories/show/[id]/page.tsx
+++ b/refine-nextjs/plugins/antd-example/src/app/categories/show/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { NumberField, Show, TextField } from "@refinedev/antd";
-import { IResourceComponentsProps, useShow } from "@refinedev/core";
+import { useShow } from "@refinedev/core";
 import { Typography } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-nextjs/plugins/headless-example/src/app/blog-posts/create/page.tsx
+++ b/refine-nextjs/plugins/headless-example/src/app/blog-posts/create/page.tsx
@@ -1,10 +1,6 @@
 "use client"
 
-import {
-    IResourceComponentsProps,
-    useNavigation,
-    useSelect,
-} from "@refinedev/core";
+import { useNavigation, useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-nextjs/plugins/headless-example/src/app/blog-posts/edit/[id]/page.tsx
+++ b/refine-nextjs/plugins/headless-example/src/app/blog-posts/edit/[id]/page.tsx
@@ -1,10 +1,6 @@
 "use client"
 
-import {
-    IResourceComponentsProps,
-    useNavigation,
-    useSelect,
-} from "@refinedev/core";
+import { useNavigation, useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-nextjs/plugins/headless-example/src/app/blog-posts/page.tsx
+++ b/refine-nextjs/plugins/headless-example/src/app/blog-posts/page.tsx
@@ -2,7 +2,6 @@
 
 import {
     GetManyResponse,
-    IResourceComponentsProps,
     useMany,
     useNavigation,
 } from "@refinedev/core";

--- a/refine-nextjs/plugins/headless-example/src/app/blog-posts/show/[id]/page.tsx
+++ b/refine-nextjs/plugins/headless-example/src/app/blog-posts/show/[id]/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import {
-    IResourceComponentsProps,
     useNavigation,
     useOne,
     useResource,

--- a/refine-nextjs/plugins/headless-example/src/app/categories/create/page.tsx
+++ b/refine-nextjs/plugins/headless-example/src/app/categories/create/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { IResourceComponentsProps, useNavigation } from "@refinedev/core";
+import { useNavigation } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-nextjs/plugins/headless-example/src/app/categories/edit/[id]/page.tsx
+++ b/refine-nextjs/plugins/headless-example/src/app/categories/edit/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { IResourceComponentsProps, useNavigation } from "@refinedev/core";
+import { useNavigation } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
 import { Controller } from "react-hook-form";

--- a/refine-nextjs/plugins/headless-example/src/app/categories/page.tsx
+++ b/refine-nextjs/plugins/headless-example/src/app/categories/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { IResourceComponentsProps, useNavigation } from "@refinedev/core";
+import { useNavigation } from "@refinedev/core";
 import { useTable } from "@refinedev/react-table";
 import { ColumnDef, flexRender } from "@tanstack/react-table";
 import React from "react";

--- a/refine-nextjs/plugins/headless-example/src/app/categories/show/[id]/page.tsx
+++ b/refine-nextjs/plugins/headless-example/src/app/categories/show/[id]/page.tsx
@@ -1,11 +1,6 @@
 "use client"
 
-import {
-    IResourceComponentsProps,
-    useNavigation,
-    useResource,
-    useShow,
-} from "@refinedev/core";
+import { useNavigation, useResource, useShow } from "@refinedev/core";
 import React from "react";
 import { Controller } from "react-hook-form";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-nextjs/plugins/mui-example/src/app/blog-posts/create/page.tsx
+++ b/refine-nextjs/plugins/mui-example/src/app/blog-posts/create/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Autocomplete, Box, MenuItem, Select, TextField } from '@mui/material'
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Create, useAutocomplete } from "@refinedev/mui";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";

--- a/refine-nextjs/plugins/mui-example/src/app/blog-posts/edit/[id]/page.tsx
+++ b/refine-nextjs/plugins/mui-example/src/app/blog-posts/edit/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { Autocomplete, Box, Select, TextField } from "@mui/material";
 import MenuItem from "@mui/material/MenuItem";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Edit, useAutocomplete } from "@refinedev/mui";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";

--- a/refine-nextjs/plugins/mui-example/src/app/blog-posts/page.tsx
+++ b/refine-nextjs/plugins/mui-example/src/app/blog-posts/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
-import { IResourceComponentsProps, useMany } from "@refinedev/core";
+import { useMany } from "@refinedev/core";
 import {
     DateField,
     DeleteButton,

--- a/refine-nextjs/plugins/mui-example/src/app/blog-posts/show/[id]/page.tsx
+++ b/refine-nextjs/plugins/mui-example/src/app/blog-posts/show/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 
 import { Stack, Typography } from "@mui/material";
-import { IResourceComponentsProps, useOne, useShow } from "@refinedev/core";
+import { useOne, useShow } from "@refinedev/core";
 import {
     DateField,
     MarkdownField,

--- a/refine-nextjs/plugins/mui-example/src/app/categories/create/page.tsx
+++ b/refine-nextjs/plugins/mui-example/src/app/categories/create/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Box, TextField } from "@mui/material";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Create } from "@refinedev/mui";
 import { useForm } from "@refinedev/react-hook-form";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-nextjs/plugins/mui-example/src/app/categories/edit/[id]/page.tsx
+++ b/refine-nextjs/plugins/mui-example/src/app/categories/edit/[id]/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Box, TextField } from "@mui/material";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Edit } from "@refinedev/mui";
 import { useForm } from "@refinedev/react-hook-form";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-nextjs/plugins/mui-example/src/app/categories/page.tsx
+++ b/refine-nextjs/plugins/mui-example/src/app/categories/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
-import { IResourceComponentsProps } from "@refinedev/core";
 import {
     DeleteButton,
     EditButton,

--- a/refine-nextjs/plugins/mui-example/src/app/categories/show/[id]/page.tsx
+++ b/refine-nextjs/plugins/mui-example/src/app/categories/show/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Stack, Typography } from "@mui/material";
-import { IResourceComponentsProps, useShow } from "@refinedev/core";
+import { useShow } from "@refinedev/core";
 import {
     NumberField,
     Show,

--- a/refine-remix/plugins/antd-example/app/routes/_layout.blog-posts._index.tsx
+++ b/refine-remix/plugins/antd-example/app/routes/_layout.blog-posts._index.tsx
@@ -7,7 +7,7 @@ import {
   ShowButton,
   useTable,
 } from "@refinedev/antd";
-import { BaseRecord, IResourceComponentsProps, useMany } from "@refinedev/core";
+import { BaseRecord, useMany } from "@refinedev/core";
 import { Space, Table } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/antd-example/app/routes/_layout.blog-posts.create.tsx
+++ b/refine-remix/plugins/antd-example/app/routes/_layout.blog-posts.create.tsx
@@ -1,5 +1,4 @@
 import { Create, useForm, useSelect } from "@refinedev/antd";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Form, Input, Select } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/antd-example/app/routes/_layout.blog-posts.edit.$id.tsx
+++ b/refine-remix/plugins/antd-example/app/routes/_layout.blog-posts.edit.$id.tsx
@@ -1,5 +1,4 @@
 import { Edit, useForm, useSelect } from "@refinedev/antd";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Form, Input, Select } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/antd-example/app/routes/_layout.blog-posts.show.$id.tsx
+++ b/refine-remix/plugins/antd-example/app/routes/_layout.blog-posts.show.$id.tsx
@@ -5,7 +5,7 @@ import {
   Show,
   TextField,
 } from "@refinedev/antd";
-import { IResourceComponentsProps, useOne, useShow } from "@refinedev/core";
+import { useOne, useShow } from "@refinedev/core";
 import { Typography } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/antd-example/app/routes/_layout.categories._index.tsx
+++ b/refine-remix/plugins/antd-example/app/routes/_layout.categories._index.tsx
@@ -5,7 +5,7 @@ import {
     ShowButton,
     useTable,
 } from "@refinedev/antd";
-import { BaseRecord, IResourceComponentsProps } from "@refinedev/core";
+import { BaseRecord } from "@refinedev/core";
 import { Space, Table } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/antd-example/app/routes/_layout.categories.create.tsx
+++ b/refine-remix/plugins/antd-example/app/routes/_layout.categories.create.tsx
@@ -1,5 +1,4 @@
 import { Create, useForm } from "@refinedev/antd";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Form, Input } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/antd-example/app/routes/_layout.categories.edit.$id.tsx
+++ b/refine-remix/plugins/antd-example/app/routes/_layout.categories.edit.$id.tsx
@@ -1,5 +1,4 @@
 import { Edit, useForm } from "@refinedev/antd";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Form, Input } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/antd-example/app/routes/_layout.categories.show.$id.tsx
+++ b/refine-remix/plugins/antd-example/app/routes/_layout.categories.show.$id.tsx
@@ -1,5 +1,5 @@
 import { NumberField, Show, TextField } from "@refinedev/antd";
-import { IResourceComponentsProps, useShow } from "@refinedev/core";
+import { useShow } from "@refinedev/core";
 import { Typography } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/headless-example/app/routes/_layout.blog-posts._index.tsx
+++ b/refine-remix/plugins/headless-example/app/routes/_layout.blog-posts._index.tsx
@@ -1,6 +1,5 @@
 import {
     GetManyResponse,
-    IResourceComponentsProps,
     useMany,
     useNavigation,
 } from "@refinedev/core";

--- a/refine-remix/plugins/headless-example/app/routes/_layout.blog-posts.create.tsx
+++ b/refine-remix/plugins/headless-example/app/routes/_layout.blog-posts.create.tsx
@@ -1,8 +1,4 @@
-import {
-    IResourceComponentsProps,
-    useNavigation,
-    useSelect,
-} from "@refinedev/core";
+import { useNavigation, useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/headless-example/app/routes/_layout.blog-posts.edit.$id.tsx
+++ b/refine-remix/plugins/headless-example/app/routes/_layout.blog-posts.edit.$id.tsx
@@ -1,8 +1,4 @@
-import {
-    IResourceComponentsProps,
-    useNavigation,
-    useSelect,
-} from "@refinedev/core";
+import { useNavigation, useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/headless-example/app/routes/_layout.blog-posts.show.$id.tsx
+++ b/refine-remix/plugins/headless-example/app/routes/_layout.blog-posts.show.$id.tsx
@@ -1,5 +1,4 @@
 import {
-    IResourceComponentsProps,
     useNavigation,
     useOne,
     useResource,

--- a/refine-remix/plugins/headless-example/app/routes/_layout.categories._index.tsx
+++ b/refine-remix/plugins/headless-example/app/routes/_layout.categories._index.tsx
@@ -1,4 +1,4 @@
-import { IResourceComponentsProps, useNavigation } from "@refinedev/core";
+import { useNavigation } from "@refinedev/core";
 import { useTable } from "@refinedev/react-table";
 import { ColumnDef, flexRender } from "@tanstack/react-table";
 import React from "react";

--- a/refine-remix/plugins/headless-example/app/routes/_layout.categories.create.tsx
+++ b/refine-remix/plugins/headless-example/app/routes/_layout.categories.create.tsx
@@ -1,4 +1,4 @@
-import { IResourceComponentsProps, useNavigation } from "@refinedev/core";
+import { useNavigation } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/headless-example/app/routes/_layout.categories.edit.$id.tsx
+++ b/refine-remix/plugins/headless-example/app/routes/_layout.categories.edit.$id.tsx
@@ -1,4 +1,4 @@
-import { IResourceComponentsProps, useNavigation } from "@refinedev/core";
+import { useNavigation } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/headless-example/app/routes/_layout.categories.show.$id.tsx
+++ b/refine-remix/plugins/headless-example/app/routes/_layout.categories.show.$id.tsx
@@ -1,5 +1,4 @@
 import {
-    IResourceComponentsProps,
     useNavigation,
     useResource,
     useShow,

--- a/refine-remix/plugins/mui-example/app/routes/_layout.blog-posts._index.tsx
+++ b/refine-remix/plugins/mui-example/app/routes/_layout.blog-posts._index.tsx
@@ -1,5 +1,5 @@
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
-import { IResourceComponentsProps, useMany } from "@refinedev/core";
+import { useMany } from "@refinedev/core";
 import {
     DateField,
     DeleteButton,

--- a/refine-remix/plugins/mui-example/app/routes/_layout.blog-posts.create.tsx
+++ b/refine-remix/plugins/mui-example/app/routes/_layout.blog-posts.create.tsx
@@ -1,5 +1,4 @@
 import { Autocomplete, Box, MenuItem, Select, TextField } from '@mui/material'
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Create, useAutocomplete } from "@refinedev/mui";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";

--- a/refine-remix/plugins/mui-example/app/routes/_layout.blog-posts.edit.$id.tsx
+++ b/refine-remix/plugins/mui-example/app/routes/_layout.blog-posts.edit.$id.tsx
@@ -1,6 +1,5 @@
 import { Autocomplete, Box, Select, TextField } from "@mui/material";
 import MenuItem from "@mui/material/MenuItem";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Edit, useAutocomplete } from "@refinedev/mui";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";

--- a/refine-remix/plugins/mui-example/app/routes/_layout.blog-posts.show.$id.tsx
+++ b/refine-remix/plugins/mui-example/app/routes/_layout.blog-posts.show.$id.tsx
@@ -1,5 +1,5 @@
 import { Stack, Typography } from "@mui/material";
-import { IResourceComponentsProps, useOne, useShow } from "@refinedev/core";
+import { useOne, useShow } from "@refinedev/core";
 import {
     DateField,
     MarkdownField,

--- a/refine-remix/plugins/mui-example/app/routes/_layout.categories._index.tsx
+++ b/refine-remix/plugins/mui-example/app/routes/_layout.categories._index.tsx
@@ -1,5 +1,4 @@
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
-import { IResourceComponentsProps } from "@refinedev/core";
 import {
     DeleteButton,
     EditButton,

--- a/refine-remix/plugins/mui-example/app/routes/_layout.categories.create.tsx
+++ b/refine-remix/plugins/mui-example/app/routes/_layout.categories.create.tsx
@@ -1,5 +1,4 @@
 import { Box, TextField } from "@mui/material";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Create } from "@refinedev/mui";
 import { useForm } from "@refinedev/react-hook-form";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/mui-example/app/routes/_layout.categories.edit.$id.tsx
+++ b/refine-remix/plugins/mui-example/app/routes/_layout.categories.edit.$id.tsx
@@ -1,5 +1,4 @@
 import { Box, TextField } from "@mui/material";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Edit } from "@refinedev/mui";
 import { useForm } from "@refinedev/react-hook-form";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-remix/plugins/mui-example/app/routes/_layout.categories.show.$id.tsx
+++ b/refine-remix/plugins/mui-example/app/routes/_layout.categories.show.$id.tsx
@@ -1,5 +1,5 @@
 import { Stack, Typography } from "@mui/material";
-import { IResourceComponentsProps, useShow } from "@refinedev/core";
+import { useShow } from "@refinedev/core";
 import {
     NumberField,
     Show,

--- a/refine-vite/plugins/antd-example/src/pages/blog-posts/create.tsx
+++ b/refine-vite/plugins/antd-example/src/pages/blog-posts/create.tsx
@@ -1,5 +1,4 @@
 import { Create, useForm, useSelect } from "@refinedev/antd";
-import { IResourceComponentsProps } from "@refinedev/core";
 import MDEditor from "@uiw/react-md-editor";
 import { Form, Input, Select } from "antd";
 import React from "react";
@@ -10,7 +9,7 @@ import React from "react";
     import { POST_CREATE_MUTATION, CATEGORIES_SELECT_QUERY } from './queries'
 <%_ } _%>
 
-export const BlogPostCreate: React.FC<IResourceComponentsProps> = () => {
+export const BlogPostCreate = () => {
     const { formProps, saveButtonProps } = useForm({
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
         meta: {

--- a/refine-vite/plugins/antd-example/src/pages/blog-posts/edit.tsx
+++ b/refine-vite/plugins/antd-example/src/pages/blog-posts/edit.tsx
@@ -1,5 +1,4 @@
 import { Edit, useForm, useSelect } from "@refinedev/antd";
-import { IResourceComponentsProps } from "@refinedev/core";
 import MDEditor from "@uiw/react-md-editor";
 import { Form, Input, Select } from "antd";
 import React from "react";
@@ -10,7 +9,7 @@ import React from "react";
     import { POST_EDIT_MUTATION, CATEGORIES_SELECT_QUERY } from './queries'
 <%_ } _%>
 
-export const BlogPostEdit: React.FC<IResourceComponentsProps> = () => {
+export const BlogPostEdit = () => {
     const { formProps, saveButtonProps, queryResult, formLoading } = useForm({
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
         meta: {

--- a/refine-vite/plugins/antd-example/src/pages/blog-posts/list.tsx
+++ b/refine-vite/plugins/antd-example/src/pages/blog-posts/list.tsx
@@ -7,7 +7,7 @@ import {
     ShowButton,
     useTable,
 } from "@refinedev/antd";
-import { BaseRecord, IResourceComponentsProps, useMany } from "@refinedev/core";
+import { BaseRecord, useMany } from "@refinedev/core";
 import { Space, Table } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
@@ -17,7 +17,7 @@ import { BLOG_POSTS_QUERY } from './queries'
     import { POSTS_LIST_QUERY } from './queries'
 <%_ } _%>
 
-export const BlogPostList: React.FC<IResourceComponentsProps> = () => {
+export const BlogPostList = () => {
     const { tableProps } = useTable({
         syncWithLocation: true,
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-vite/plugins/antd-example/src/pages/blog-posts/show.tsx
+++ b/refine-vite/plugins/antd-example/src/pages/blog-posts/show.tsx
@@ -5,7 +5,7 @@ import {
     Show,
     TextField,
 } from "@refinedev/antd";
-import { IResourceComponentsProps, useOne, useShow } from "@refinedev/core";
+import { useOne, useShow } from "@refinedev/core";
 import { Typography } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
@@ -17,7 +17,7 @@ import React from "react";
 
 const { Title } = Typography;
 
-export const BlogPostShow: React.FC<IResourceComponentsProps> = () => {
+export const BlogPostShow = () => {
     const { queryResult } = useShow({
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
         meta: {

--- a/refine-vite/plugins/antd-example/src/pages/categories/create.tsx
+++ b/refine-vite/plugins/antd-example/src/pages/categories/create.tsx
@@ -1,5 +1,4 @@
 import { Create, useForm } from "@refinedev/antd";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Form, Input } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
@@ -9,7 +8,7 @@ import React from "react";
     import { CATEGORY_CREATE_MUTATION } from './queries'
 <%_ } _%>
 
-export const CategoryCreate: React.FC<IResourceComponentsProps> = () => {
+export const CategoryCreate = () => {
     const { formProps, saveButtonProps } = useForm({
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
         meta: {

--- a/refine-vite/plugins/antd-example/src/pages/categories/edit.tsx
+++ b/refine-vite/plugins/antd-example/src/pages/categories/edit.tsx
@@ -1,5 +1,4 @@
 import { Edit, useForm } from "@refinedev/antd";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Form, Input } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
@@ -10,7 +9,7 @@ import React from "react";
 <%_ } _%>
 
 
-export const CategoryEdit: React.FC<IResourceComponentsProps> = () => {
+export const CategoryEdit = () => {
     const { formProps, saveButtonProps } = useForm({
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
         meta: {

--- a/refine-vite/plugins/antd-example/src/pages/categories/list.tsx
+++ b/refine-vite/plugins/antd-example/src/pages/categories/list.tsx
@@ -5,7 +5,7 @@ import {
     ShowButton,
     useTable,
 } from "@refinedev/antd";
-import { BaseRecord, IResourceComponentsProps } from "@refinedev/core";
+import { BaseRecord } from "@refinedev/core";
 import { Space, Table } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
@@ -16,7 +16,7 @@ import React from "react";
 <%_ } _%>
 
 
-export const CategoryList: React.FC<IResourceComponentsProps> = () => {
+export const CategoryList = () => {
     const { tableProps } = useTable({
         syncWithLocation: true,
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-vite/plugins/antd-example/src/pages/categories/show.tsx
+++ b/refine-vite/plugins/antd-example/src/pages/categories/show.tsx
@@ -1,5 +1,5 @@
 import { NumberField, Show, TextField } from "@refinedev/antd";
-import { IResourceComponentsProps, useShow } from "@refinedev/core";
+import { useShow } from "@refinedev/core";
 import { Typography } from "antd";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
@@ -11,7 +11,7 @@ import React from "react";
 
 const { Title } = Typography;
 
-export const CategoryShow: React.FC<IResourceComponentsProps> = () => {
+export const CategoryShow = () => {
     const { queryResult } = useShow({
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
         meta: {

--- a/refine-vite/plugins/headless-example/src/pages/blog-posts/create.tsx
+++ b/refine-vite/plugins/headless-example/src/pages/blog-posts/create.tsx
@@ -1,8 +1,4 @@
-import {
-    IResourceComponentsProps,
-    useNavigation,
-    useSelect,
-} from "@refinedev/core";
+import { useNavigation, useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
@@ -13,7 +9,7 @@ import React from "react";
 <%_ } _%>
 
 
-export const BlogPostCreate: React.FC<IResourceComponentsProps> = () => {
+export const BlogPostCreate = () => {
     const { list } = useNavigation();
 
     const {

--- a/refine-vite/plugins/headless-example/src/pages/blog-posts/edit.tsx
+++ b/refine-vite/plugins/headless-example/src/pages/blog-posts/edit.tsx
@@ -1,8 +1,4 @@
-import {
-    IResourceComponentsProps,
-    useNavigation,
-    useSelect,
-} from "@refinedev/core";
+import { useNavigation, useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
@@ -12,7 +8,7 @@ import React from "react";
     import { POST_EDIT_MUTATION, CATEGORIES_SELECT_QUERY } from './queries'
 <%_ } _%>
 
-export const BlogPostEdit: React.FC<IResourceComponentsProps> = () => {
+export const BlogPostEdit = () => {
     const { list } = useNavigation();
 
     const {

--- a/refine-vite/plugins/headless-example/src/pages/blog-posts/list.tsx
+++ b/refine-vite/plugins/headless-example/src/pages/blog-posts/list.tsx
@@ -1,6 +1,5 @@
 import {
     GetManyResponse,
-    IResourceComponentsProps,
     useMany,
     useNavigation,
 } from "@refinedev/core";
@@ -14,7 +13,7 @@ import { BLOG_POSTS_QUERY } from './queries'
     import { POSTS_LIST_QUERY } from './queries'
 <%_ } _%>
 
-export const BlogPostList: React.FC<IResourceComponentsProps> = () => {
+export const BlogPostList = () => {
     const columns = React.useMemo<ColumnDef<any>[]>(
         () => [
             {

--- a/refine-vite/plugins/headless-example/src/pages/blog-posts/show.tsx
+++ b/refine-vite/plugins/headless-example/src/pages/blog-posts/show.tsx
@@ -1,5 +1,4 @@
 import {
-    IResourceComponentsProps,
     useNavigation,
     useOne,
     useResource,
@@ -13,7 +12,7 @@ import React from "react";
     import { POST_SHOW_QUERY } from './queries'
 <%_ } _%>
 
-export const BlogPostShow: React.FC<IResourceComponentsProps> = () => {
+export const BlogPostShow = () => {
     const { edit, list } = useNavigation();
     const { id } = useResource();
     const { queryResult } = useShow({

--- a/refine-vite/plugins/headless-example/src/pages/categories/create.tsx
+++ b/refine-vite/plugins/headless-example/src/pages/categories/create.tsx
@@ -1,4 +1,4 @@
-import { IResourceComponentsProps, useNavigation } from "@refinedev/core";
+import { useNavigation } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
@@ -8,7 +8,7 @@ import React from "react";
     import { CATEGORY_CREATE_MUTATION } from './queries'
 <%_ } _%>
 
-export const CategoryCreate: React.FC<IResourceComponentsProps> = () => {
+export const CategoryCreate = () => {
     const { list } = useNavigation();
 
     const {

--- a/refine-vite/plugins/headless-example/src/pages/categories/edit.tsx
+++ b/refine-vite/plugins/headless-example/src/pages/categories/edit.tsx
@@ -1,4 +1,4 @@
-import { IResourceComponentsProps, useNavigation } from "@refinedev/core";
+import { useNavigation } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
@@ -8,7 +8,7 @@ import React from "react";
     import { CATEGORY_EDIT_MUTATION } from './queries'
 <%_ } _%>
 
-export const CategoryEdit: React.FC<IResourceComponentsProps> = () => {
+export const CategoryEdit = () => {
     const { list } = useNavigation();
 
     const {

--- a/refine-vite/plugins/headless-example/src/pages/categories/list.tsx
+++ b/refine-vite/plugins/headless-example/src/pages/categories/list.tsx
@@ -1,4 +1,4 @@
-import { IResourceComponentsProps, useNavigation } from "@refinedev/core";
+import { useNavigation } from "@refinedev/core";
 import { useTable } from "@refinedev/react-table";
 import { ColumnDef, flexRender } from "@tanstack/react-table";
 import React from "react";
@@ -10,7 +10,7 @@ import { CATEGORIES_QUERY } from './queries'
 <%_ } _%>
 
 
-export const CategoryList: React.FC<IResourceComponentsProps> = () => {
+export const CategoryList = () => {
     const columns = React.useMemo<ColumnDef<any>[]>(
         () => [
             {

--- a/refine-vite/plugins/headless-example/src/pages/categories/show.tsx
+++ b/refine-vite/plugins/headless-example/src/pages/categories/show.tsx
@@ -1,5 +1,4 @@
 import {
-    IResourceComponentsProps,
     useNavigation,
     useResource,
     useShow,
@@ -12,7 +11,7 @@ import React from "react";
     import { CATEGORY_SHOW_QUERY } from './queries'
 <%_ } _%>
 
-export const CategoryShow: React.FC<IResourceComponentsProps> = () => {
+export const CategoryShow = () => {
     const { edit, list } = useNavigation();
     const { id } = useResource();
     const { queryResult } = useShow({

--- a/refine-vite/plugins/mui-example/src/pages/blog-posts/create.tsx
+++ b/refine-vite/plugins/mui-example/src/pages/blog-posts/create.tsx
@@ -1,5 +1,4 @@
 import { Autocomplete, Box, MenuItem, Select, TextField } from '@mui/material'
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Create, useAutocomplete } from "@refinedev/mui";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
@@ -11,7 +10,7 @@ import { Controller } from "react-hook-form";
     import { POST_CREATE_MUTATION, CATEGORIES_SELECT_QUERY } from './queries'
 <%_ } _%>
 
-export const BlogPostCreate: React.FC<IResourceComponentsProps> = () => {
+export const BlogPostCreate = () => {
     const {
         saveButtonProps,
         refineCore: {  formLoading },

--- a/refine-vite/plugins/mui-example/src/pages/blog-posts/edit.tsx
+++ b/refine-vite/plugins/mui-example/src/pages/blog-posts/edit.tsx
@@ -1,6 +1,5 @@
 import { Autocomplete, Box, Select, TextField } from "@mui/material";
 import MenuItem from "@mui/material/MenuItem";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Edit, useAutocomplete } from "@refinedev/mui";
 import { useForm } from "@refinedev/react-hook-form";
 import React from "react";
@@ -12,7 +11,7 @@ import { Controller } from "react-hook-form";
     import { POST_EDIT_MUTATION, CATEGORIES_SELECT_QUERY } from './queries'
 <%_ } _%>
 
-export const BlogPostEdit: React.FC<IResourceComponentsProps> = () => {
+export const BlogPostEdit = () => {
     const {
         saveButtonProps,
         refineCore: { queryResult, formLoading },

--- a/refine-vite/plugins/mui-example/src/pages/blog-posts/list.tsx
+++ b/refine-vite/plugins/mui-example/src/pages/blog-posts/list.tsx
@@ -1,5 +1,5 @@
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
-import { IResourceComponentsProps, useMany } from "@refinedev/core";
+import { useMany } from "@refinedev/core";
 import {
     DateField,
     DeleteButton,
@@ -18,7 +18,7 @@ import React from "react";
 <%_ } _%>
 
     
-export const BlogPostList: React.FC<IResourceComponentsProps> = () => {
+export const BlogPostList = () => {
     const { dataGridProps } = useDataGrid({
         syncWithLocation: true,
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>

--- a/refine-vite/plugins/mui-example/src/pages/blog-posts/show.tsx
+++ b/refine-vite/plugins/mui-example/src/pages/blog-posts/show.tsx
@@ -1,5 +1,5 @@
 import { Stack, Typography } from "@mui/material";
-import { IResourceComponentsProps, useOne, useShow } from "@refinedev/core";
+import { useOne, useShow } from "@refinedev/core";
 import {
     DateField,
     MarkdownField,
@@ -14,7 +14,7 @@ import {
     import { POST_SHOW_QUERY } from './queries'
 <%_ } _%>
 
-export const BlogPostShow: React.FC<IResourceComponentsProps> = () => {
+export const BlogPostShow = () => {
     const { queryResult } = useShow({
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
         meta: {

--- a/refine-vite/plugins/mui-example/src/pages/categories/create.tsx
+++ b/refine-vite/plugins/mui-example/src/pages/categories/create.tsx
@@ -1,5 +1,4 @@
 import { Box, TextField } from "@mui/material";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Create } from "@refinedev/mui";
 import { useForm } from "@refinedev/react-hook-form";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
@@ -9,7 +8,7 @@ import { useForm } from "@refinedev/react-hook-form";
     import { CATEGORY_CREATE_MUTATION } from './queries'
 <%_ } _%>
 
-export const CategoryCreate: React.FC<IResourceComponentsProps> = () => {
+export const CategoryCreate = () => {
     const {
         saveButtonProps,
         refineCore: { formLoading },

--- a/refine-vite/plugins/mui-example/src/pages/categories/edit.tsx
+++ b/refine-vite/plugins/mui-example/src/pages/categories/edit.tsx
@@ -1,5 +1,4 @@
 import { Box, TextField } from "@mui/material";
-import { IResourceComponentsProps } from "@refinedev/core";
 import { Edit } from "@refinedev/mui";
 import { useForm } from "@refinedev/react-hook-form";
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
@@ -9,7 +8,7 @@ import { useForm } from "@refinedev/react-hook-form";
     import { CATEGORY_EDIT_MUTATION } from './queries'
 <%_ } _%>
 
-export const CategoryEdit: React.FC<IResourceComponentsProps> = () => {
+export const CategoryEdit = () => {
     const {
         saveButtonProps,
         register,

--- a/refine-vite/plugins/mui-example/src/pages/categories/list.tsx
+++ b/refine-vite/plugins/mui-example/src/pages/categories/list.tsx
@@ -1,5 +1,4 @@
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
-import { IResourceComponentsProps } from "@refinedev/core";
 import {
     DeleteButton,
     EditButton,
@@ -15,7 +14,7 @@ import React from "react";
     import { CATEGORIES_LIST_QUERY } from './queries'
 <%_ } _%>
 
-export const CategoryList: React.FC<IResourceComponentsProps> = () => {
+export const CategoryList = () => {
     const { dataGridProps } = useDataGrid({
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
         meta: {

--- a/refine-vite/plugins/mui-example/src/pages/categories/show.tsx
+++ b/refine-vite/plugins/mui-example/src/pages/categories/show.tsx
@@ -1,5 +1,5 @@
 import { Stack, Typography } from "@mui/material";
-import { IResourceComponentsProps, useShow } from "@refinedev/core";
+import { useShow } from "@refinedev/core";
 import {
     NumberField,
     Show,
@@ -12,7 +12,7 @@ import {
     import { CATEGORY_SHOW_QUERY } from './queries'
 <%_ } _%>
 
-export const CategoryShow: React.FC<IResourceComponentsProps> = () => {
+export const CategoryShow = () => {
     const { queryResult } = useShow({
 <%_ if (answers["data-provider"] === "data-provider-hasura") { _%>
             meta: {


### PR DESCRIPTION
Removed the imports and usages of redundant `IResourceComponentProps` type which only works with legacy routers and `RefineRoutes` components.