### PR TITLE
fix: vite.config should be only included on tsconfig.node

### DIFF
--- a/refine-vite/template/_tsconfig.json
+++ b/refine-vite/template/_tsconfig.json
@@ -16,6 +16,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src", "vite.config.ts"],
+  "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
We get build error when "vite.config.ts" is included in tsconfig.json:

```bash
npm run build

> vite-test@0.1.0 build
> tsc && refine build

error TS6305: Output file '/Users/alicanerdurmaz/Desktop/vite-test/vite.config.d.ts' has not been built from source file '/Users/alicanerdurmaz/Desktop/vite-test/vite.config.ts'.
  The file is in the program because:
    Matched by include pattern 'vite.config.ts' in '/Users/alicanerdurmaz/Desktop/vite-test/tsconfig.json'

  tsconfig.json:19:22
    19   "include": ["src", "vite.config.ts"],
                            ~~~~~~~~~~~~~~~~
    File is matched by include pattern specified here.
```

according the vite's default settings, "vite.config.ts" should be only included on tsconfig.node.json