### PR TITLE
chore(antd): bump antd package versions

### DIFF
--- a/refine-nextjs/plugins/antd/package.json
+++ b/refine-nextjs/plugins/antd/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "@refinedev/antd": "^5.37.4",
-    "@ant-design/icons": "^5.0.1",
-    "antd": "^5.0.5",
+    "@refinedev/antd": "^5.44.0",
+    "@ant-design/icons": "^5.5.1",
+    "antd": "^5.17.0",
     "js-cookie": "^3.0.5",
     "@ant-design/nextjs-registry": "^1.0.0"
   },

--- a/refine-vite/plugins/antd/package.json
+++ b/refine-vite/plugins/antd/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@refinedev/antd": "^5.37.4",
-    "antd": "^5.0.5",
-    "@ant-design/icons": "^5.0.1"
+    "@refinedev/antd": "^5.44.0",
+    "antd": "^5.17.0",
+    "@ant-design/icons": "^5.5.1"
   }
 }


### PR DESCRIPTION
Depends on https://github.com/refinedev/refine/pull/6369

Updates the `@refinedev/antd` version to the next minor and updates `antd` and `@ant-design/icons` versions to the latest ranges.